### PR TITLE
Enhance analysis coverage and reporting outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,36 @@
-# Firmware_Analyzer
-Firmware Analyzer
+# Drone Firmware Analyzer
+
+Drone Firmware Analyzer is a modular Go toolkit for extracting and auditing
+firmware images from small IoT and drone platforms. It emphasises quick
+analysis workflows by combining light-weight extraction, configuration parsing,
+service discovery, secrets scanning, and ELF hardening inspection into a single
+CLI entrypoint.
+
+## Features
+
+- Firmware extraction with built-in support for tar/tgz/zip images and
+  workspace normalisation
+- Filesystem probing for SquashFS, UBI and ext files
+- Configuration parsing across JSON, XML, TOML and INI with credential
+  heuristics
+- Service detection for SysV/BUSYBOX init scripts and systemd units
+- Regex and entropy based secrets scanning with allow-list support
+- Binary hardening analysis with Markdown/HTML reporting
+
+## Usage
+
+```bash
+go run ./cmd/analyzer --fw /path/to/firmware.bin --out /tmp/report
+```
+
+The analyzer writes the extracted workspace and generated reports inside the
+specified output directory. When `--out` is omitted a temporary workspace is
+created alongside the extracted firmware.
+
+## Development
+
+Run the full test suite before submitting changes:
+
+```bash
+go test ./...
+```

--- a/cmd/analyzer/main.go
+++ b/cmd/analyzer/main.go
@@ -1,0 +1,135 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"firmwareanalyzer/pkg/binaryinspector"
+	"firmwareanalyzer/pkg/configparser"
+	"firmwareanalyzer/pkg/extractor"
+	"firmwareanalyzer/pkg/filesystem"
+	"firmwareanalyzer/pkg/report"
+	"firmwareanalyzer/pkg/secrets"
+	"firmwareanalyzer/pkg/service"
+)
+
+func main() {
+	firmwarePath := flag.String("fw", "", "path to the firmware image")
+	outputDir := flag.String("out", "", "directory for reports and working files")
+	formatFlag := flag.String("report-formats", "markdown,html,json", "comma-separated list of report formats (markdown, html, json)")
+	flag.Parse()
+
+	if *firmwarePath == "" {
+		log.Fatal("missing required --fw flag")
+	}
+
+	ctx := context.Background()
+	logger := log.New(os.Stdout, "analyzer ", log.LstdFlags)
+	start := time.Now()
+
+	workDir := ""
+	if *outputDir != "" {
+		workDir = filepath.Join(*outputDir, "workspace")
+	}
+
+	ext := extractor.New(extractor.Options{WorkDir: workDir, PreserveTemp: true}, logger)
+	extraction, err := ext.Extract(ctx, *firmwarePath)
+	if err != nil {
+		log.Fatalf("extraction failed: %v", err)
+	}
+
+	analysisRoot := extraction.OutputDir
+
+	fsDetector := filesystem.NewDetector(logger)
+	mounts, err := fsDetector.Detect(ctx, analysisRoot)
+	if err != nil {
+		logger.Printf("filesystem detection error: %v", err)
+	}
+
+	cfgParser := configparser.NewParser(logger)
+	configs, err := cfgParser.Parse(ctx, analysisRoot)
+	if err != nil {
+		logger.Printf("config parsing error: %v", err)
+	}
+
+	svcDetector := service.NewDetector(logger)
+	services, err := svcDetector.Detect(ctx, analysisRoot)
+	if err != nil {
+		logger.Printf("service detection error: %v", err)
+	}
+
+	secretScanner := secrets.NewScanner(logger, nil)
+	secretFindings, err := secretScanner.Scan(ctx, analysisRoot)
+	if err != nil {
+		logger.Printf("secret scanning error: %v", err)
+	}
+
+	inspector := binaryinspector.NewInspector(logger)
+	binaries, err := inspector.Inspect(ctx, analysisRoot)
+	if err != nil {
+		logger.Printf("binary inspection error: %v", err)
+	}
+
+	summary := report.Summary{
+		Firmware:    *firmwarePath,
+		Extraction:  extraction,
+		FileSystems: mounts,
+		Configs:     configs,
+		Services:    services,
+		Secrets:     secretFindings,
+		Binaries:    binaries,
+	}
+
+	formats, err := parseReportFormats(*formatFlag)
+	if err != nil {
+		log.Fatalf("invalid report format: %v", err)
+	}
+
+	generator := report.NewGenerator(logger)
+	outDir := *outputDir
+	if outDir == "" {
+		outDir = filepath.Join(extraction.OutputDir, "report")
+	}
+	paths, err := generator.WriteFiles(summary, outDir, formats)
+	if err != nil {
+		log.Fatalf("write report: %v", err)
+	}
+
+	logger.Printf("reports written (md=%s html=%s json=%s)", paths.Markdown, paths.HTML, paths.JSON)
+	logger.Printf("analysis complete in %s", time.Since(start).Round(time.Millisecond))
+}
+
+func parseReportFormats(value string) (report.Formats, error) {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return report.DefaultFormats, nil
+	}
+	var formats report.Formats
+	tokens := strings.Split(trimmed, ",")
+	for _, token := range tokens {
+		t := strings.TrimSpace(strings.ToLower(token))
+		if t == "" {
+			continue
+		}
+		switch t {
+		case "md", "markdown":
+			formats.Markdown = true
+		case "html":
+			formats.HTML = true
+		case "json":
+			formats.JSON = true
+		default:
+			return report.Formats{}, fmt.Errorf("unknown report format %q", token)
+		}
+	}
+	if !formats.Markdown && !formats.HTML && !formats.JSON {
+		return report.Formats{}, fmt.Errorf("no valid report formats selected")
+	}
+	return formats, nil
+}

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -1,0 +1,41 @@
+# Design Overview
+
+Drone Firmware Analyzer is structured as a collection of focused Go packages
+coordinated by a thin CLI layer. Each package owns a single responsibility and
+exposes testable APIs so that future modules (e.g. SBOM generation or CVE
+matching) can be integrated without modifying the existing workflow heavily.
+
+## Package Responsibilities
+
+- `pkg/extractor` normalises firmware archives into a workspace directory and
+  records partition metadata for downstream modules.
+- `pkg/filesystem` performs signature-based identification of embedded
+  filesystem images without needing privileged mounts.
+- `pkg/configparser` flattens JSON, XML, TOML and INI configuration files into
+  dot-notated key/value pairs that higher layers can consume.
+- `pkg/service` inventories init scripts and unit files to provide visibility
+  into boot-time services.
+- `pkg/secrets` scans text content for credential material using regular
+  expressions, Shannon entropy and optional allow-lists.
+- `pkg/binaryinspector` analyses ELF binaries for hardening settings such as
+  RELRO, NX and PIE and renders Markdown tables for reports.
+- `pkg/report` composes module results into Markdown and HTML artefacts.
+- `pkg/utils` hosts shared helpers for map flattening, entropy calculations and
+  heuristic utilities.
+
+## Workflow
+
+1. **Extraction** – The CLI invokes the extractor to unpack the firmware image
+   into a workspace, retaining metadata about detected partitions.
+2. **Scanning** – Filesystem detection, configuration parsing, service
+   discovery, secret scanning and binary inspection operate on the workspace in
+   parallel-friendly fashion (currently sequenced within the CLI for clarity).
+3. **Reporting** – The report generator aggregates module outputs into Markdown
+   and HTML documents, preserving tabular data for further processing.
+
+## Testing Strategy
+
+Each package ships with focused unit tests using temporary directories and
+small fixtures to keep the test suite fast and deterministic. The tests validate
+both success paths and heuristic triggers (e.g. credential detection) to guard
+against regressions.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,28 @@
+# Roadmap
+
+The current implementation focuses on core workflows suitable for rapid firmware
+triage. The following milestones track planned enhancements:
+
+## Short Term
+
+- Add optional integration with external extraction tools (binwalk/unblob) when
+  available on the host system.
+- Expand filesystem detection to parse partition tables (MTD, GPT) and identify
+  mounted rootfs directories more accurately.
+- Improve configuration parsing coverage with YAML and proprietary formats
+  commonly seen in drone ecosystems.
+
+## Medium Term
+
+- Introduce CVE enrichment by hashing binaries and querying vulnerability data
+  sources.
+- Generate SBOM artefacts (SPDX/CycloneDX) for firmware contents.
+- Provide structured JSON output alongside Markdown/HTML for ingestion into
+  other tooling.
+
+## Long Term
+
+- Implement a plugin framework so teams can drop-in custom checks without
+  modifying the core.
+- Offer a web dashboard for browsing analysis history and diffing firmware
+  versions over time.

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -1,0 +1,41 @@
+# Usage Guide
+
+The Drone Firmware Analyzer command line interface orchestrates firmware
+extraction and analysis modules. The minimal invocation requires the firmware
+image path:
+
+```bash
+go run ./cmd/analyzer --fw firmware.tgz
+```
+
+## Flags
+
+- `--fw` (required): path to the firmware image archive or directory.
+- `--out`: optional directory where the workspace and generated reports will be
+  written. When omitted, a temporary directory under the system temp location is
+  created automatically.
+
+## Output Structure
+
+```
+<output>/
+├── workspace/       # normalised extraction root
+│   ├── ...
+└── report/
+    ├── report.md    # Markdown summary
+    └── report.html  # HTML view
+```
+
+If `--out` is not provided the report directory is written inside the extracted
+workspace.
+
+## Adding Custom Modules
+
+The analyzer pipeline is intentionally modular. To integrate a new analysis
+stage:
+
+1. Create a package under `pkg/` exposing a Go API that accepts the extraction
+   root path and returns structured findings.
+2. Add unit tests under `tests/` using temporary fixtures to validate behaviour.
+3. Wire the new package into `cmd/analyzer/main.go`, feeding the results into the
+   `report.Summary` structure so they surface in the generated reports.

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module firmwareanalyzer
+
+go 1.22
+
+require gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/pkg/binaryinspector/binaryinspector.go
+++ b/pkg/binaryinspector/binaryinspector.go
@@ -1,0 +1,305 @@
+package binaryinspector
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"debug/elf"
+)
+
+// ErrNotELF is returned when the inspected file is not an ELF binary.
+var ErrNotELF = errors.New("not an ELF binary")
+
+// RELROLevel represents the strength of RELRO hardening applied to an ELF binary.
+type RELROLevel string
+
+const (
+	// RELRONone indicates that the binary does not request RELRO protection.
+	RELRONone RELROLevel = "none"
+	// RELROPartial indicates that the binary has PT_GNU_RELRO but performs lazy binding.
+	RELROPartial RELROLevel = "partial"
+	// RELROFull indicates that the binary has PT_GNU_RELRO and enforces immediate binding.
+	RELROFull RELROLevel = "full"
+)
+
+// Result holds hardening attributes detected for a single ELF binary.
+type Result struct {
+	Path         string     `json:"path"`
+	Type         string     `json:"type"`
+	Architecture string     `json:"architecture"`
+	RELRO        RELROLevel `json:"relro"`
+	NXEnabled    bool       `json:"nx_enabled"`
+	PIEEnabled   bool       `json:"pie_enabled"`
+	Stripped     bool       `json:"stripped"`
+	Interpreter  string     `json:"interpreter,omitempty"`
+	Err          string     `json:"error,omitempty"`
+}
+
+// MarkdownRow returns a Markdown formatted table row describing the binary.
+func (r Result) MarkdownRow() string {
+	status := func(b bool) string {
+		if b {
+			return "✅"
+		}
+		return "❌"
+	}
+
+	relro := strings.ToUpper(string(r.RELRO))
+	if relro == "" {
+		relro = "UNKNOWN"
+	}
+
+	stripped := "No"
+	if r.Stripped {
+		stripped = "Yes"
+	}
+
+	interpreter := r.Interpreter
+	if interpreter == "" {
+		interpreter = "-"
+	}
+
+	return fmt.Sprintf("| %s | %s | %s | %s | %s | %s | %s | %s |",
+		r.Path, r.Type, r.Architecture, relro, status(r.NXEnabled), status(r.PIEEnabled), stripped, interpreter)
+}
+
+// Inspector analyses ELF binaries for common hardening flags.
+type Inspector struct {
+	logger *log.Logger
+}
+
+// NewInspector returns a new Inspector. If logger is nil, logging is discarded.
+func NewInspector(logger *log.Logger) *Inspector {
+	if logger == nil {
+		logger = log.New(io.Discard, "binaryinspector", log.LstdFlags)
+	}
+	return &Inspector{logger: logger}
+}
+
+// Inspect walks the given root directory and inspects any ELF binaries found.
+// The context allows the walk to be cancelled early. Any errors encountered
+// during inspection are captured in the Result.Err field so that processing can
+// continue for other binaries.
+func (i *Inspector) Inspect(ctx context.Context, root string) ([]Result, error) {
+	var results []Result
+	walkErr := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		if d.IsDir() {
+			return nil
+		}
+
+		info, statErr := d.Info()
+		if statErr != nil {
+			return statErr
+		}
+
+		if !info.Mode().IsRegular() {
+			return nil
+		}
+
+		res, inspectErr := i.inspectFile(path)
+		switch {
+		case errors.Is(inspectErr, ErrNotELF):
+			return nil
+		case inspectErr != nil:
+			res.Err = inspectErr.Error()
+			results = append(results, res)
+		default:
+			results = append(results, res)
+		}
+		return nil
+	})
+	if walkErr != nil {
+		return nil, walkErr
+	}
+	return results, nil
+}
+
+func (i *Inspector) inspectFile(path string) (Result, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return Result{Path: path}, fmt.Errorf("open file: %w", err)
+	}
+	defer file.Close()
+
+	header := make([]byte, 4)
+	if _, err := io.ReadFull(file, header); err != nil {
+		return Result{Path: path}, fmt.Errorf("read header: %w", err)
+	}
+	if !bytes.Equal(header, []byte(elf.ELFMAG)) {
+		return Result{Path: path}, ErrNotELF
+	}
+
+	if _, err := file.Seek(0, io.SeekStart); err != nil {
+		return Result{Path: path}, fmt.Errorf("seek: %w", err)
+	}
+
+	ef, err := elf.NewFile(file)
+	if err != nil {
+		return Result{Path: path}, fmt.Errorf("parse ELF: %w", err)
+	}
+	defer ef.Close()
+
+	result := Result{Path: path}
+
+	result.Type = ef.FileHeader.Type.String()
+	result.Architecture = ef.FileHeader.Machine.String()
+	result.PIEEnabled = ef.FileHeader.Type == elf.ET_DYN
+	result.NXEnabled = detectNX(ef)
+
+	relro, relroErr := detectRELRO(ef)
+	if relroErr != nil {
+		return result, fmt.Errorf("detect RELRO: %w", relroErr)
+	}
+	result.RELRO = relro
+
+	result.Stripped = isStripped(ef)
+	result.Interpreter = interpreterPath(ef)
+
+	return result, nil
+}
+
+func detectNX(f *elf.File) bool {
+	for _, prog := range f.Progs {
+		if prog.Type == elf.PT_GNU_STACK {
+			return prog.Flags&elf.PF_X == 0
+		}
+	}
+	return false
+}
+
+func detectRELRO(f *elf.File) (RELROLevel, error) {
+	var hasRelro bool
+	for _, prog := range f.Progs {
+		if prog.Type == elf.PT_GNU_RELRO {
+			hasRelro = true
+			break
+		}
+	}
+	if !hasRelro {
+		return RELRONone, nil
+	}
+
+	tags, err := dynamicTags(f)
+	if err != nil {
+		return RELRONone, err
+	}
+
+	if val, ok := tags[elf.DT_BIND_NOW]; ok && val != 0 {
+		return RELROFull, nil
+	}
+	if val, ok := tags[elf.DT_FLAGS]; ok && elf.DynFlag(val)&elf.DF_BIND_NOW != 0 {
+		return RELROFull, nil
+	}
+	if val, ok := tags[elf.DT_FLAGS_1]; ok && elf.DynFlag1(val)&elf.DF_1_NOW != 0 {
+		return RELROFull, nil
+	}
+
+	return RELROPartial, nil
+}
+
+func isStripped(f *elf.File) bool {
+	symtab := f.Section(".symtab")
+	if symtab == nil {
+		return true
+	}
+	return symtab.Size == 0
+}
+
+func interpreterPath(f *elf.File) string {
+	sec := f.Section(".interp")
+	if sec == nil {
+		return ""
+	}
+
+	data, err := sec.Data()
+	if err != nil {
+		return ""
+	}
+
+	return strings.TrimRight(string(data), "\x00")
+}
+
+func dynamicTags(f *elf.File) (map[elf.DynTag]uint64, error) {
+	dynSec := f.Section(".dynamic")
+	if dynSec == nil {
+		return map[elf.DynTag]uint64{}, nil
+	}
+
+	data, err := dynSec.Data()
+	if err != nil {
+		return nil, err
+	}
+
+	tags := make(map[elf.DynTag]uint64)
+	reader := bytes.NewReader(data)
+
+	switch f.Class {
+	case elf.ELFCLASS32:
+		for {
+			var entry elf.Dyn32
+			if err := binary.Read(reader, f.ByteOrder, &entry); err != nil {
+				if errors.Is(err, io.EOF) {
+					break
+				}
+				return nil, err
+			}
+			if elf.DynTag(entry.Tag) == elf.DT_NULL {
+				break
+			}
+			tags[elf.DynTag(entry.Tag)] = uint64(entry.Val)
+		}
+	case elf.ELFCLASS64:
+		for {
+			var entry elf.Dyn64
+			if err := binary.Read(reader, f.ByteOrder, &entry); err != nil {
+				if errors.Is(err, io.EOF) {
+					break
+				}
+				return nil, err
+			}
+			if elf.DynTag(entry.Tag) == elf.DT_NULL {
+				break
+			}
+			tags[elf.DynTag(entry.Tag)] = entry.Val
+		}
+	default:
+		return nil, fmt.Errorf("unsupported ELF class: %s", f.Class)
+	}
+
+	return tags, nil
+}
+
+// CollectMarkdownTable renders results into a Markdown table body.
+func CollectMarkdownTable(results []Result) string {
+	if len(results) == 0 {
+		return ""
+	}
+
+	var builder strings.Builder
+	builder.WriteString("| Path | Type | Arch | RELRO | NX | PIE | Stripped | Interpreter |\n")
+	builder.WriteString("| --- | --- | --- | --- | --- | --- | --- | --- |\n")
+	for _, res := range results {
+		builder.WriteString(res.MarkdownRow())
+		builder.WriteByte('\n')
+	}
+	return builder.String()
+}

--- a/pkg/configparser/configparser.go
+++ b/pkg/configparser/configparser.go
@@ -1,0 +1,278 @@
+package configparser
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"encoding/xml"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"firmwareanalyzer/pkg/utils"
+
+	yaml "gopkg.in/yaml.v3"
+)
+
+// Parameter represents a flattened configuration entry discovered within a
+// parsed configuration file.
+type Parameter struct {
+	Key        string `json:"key"`
+	Value      string `json:"value"`
+	Credential bool   `json:"credential"`
+}
+
+// Finding groups the parameters produced from parsing a single configuration
+// file.
+type Finding struct {
+	File   string      `json:"file"`
+	Format string      `json:"format"`
+	Params []Parameter `json:"parameters"`
+}
+
+// Parser loads configuration files from extracted firmware directories and
+// normalises them into flattened key/value pairs for downstream analysis.
+type Parser struct {
+	maxSize int64
+	logger  *log.Logger
+}
+
+// NewParser instantiates a Parser with sane defaults.
+func NewParser(logger *log.Logger) *Parser {
+	if logger == nil {
+		logger = log.New(io.Discard, "configparser", log.LstdFlags)
+	}
+	return &Parser{maxSize: 2 << 20, logger: logger}
+}
+
+// Parse walks the provided root directory collecting configuration findings
+// for supported formats (JSON, XML, YAML, TOML, and INI).
+func (p *Parser) Parse(ctx context.Context, root string) ([]Finding, error) {
+	var findings []Finding
+	err := filepath.WalkDir(root, func(path string, d os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.IsDir() {
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		format := detectFormat(path)
+		if format == "" {
+			return nil
+		}
+		finding, err := p.parseFile(path, format)
+		if err != nil {
+			return err
+		}
+		if len(finding.Params) > 0 {
+			findings = append(findings, finding)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return findings, nil
+}
+
+func (p *Parser) parseFile(path, format string) (Finding, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return Finding{}, fmt.Errorf("stat config: %w", err)
+	}
+	if info.Size() > p.maxSize {
+		return Finding{}, fmt.Errorf("config file too large: %s", path)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return Finding{}, fmt.Errorf("read config: %w", err)
+	}
+
+	var flat map[string]string
+	switch format {
+	case "json":
+		var v any
+		dec := json.NewDecoder(bytes.NewReader(data))
+		dec.UseNumber()
+		if err := dec.Decode(&v); err != nil {
+			return Finding{}, fmt.Errorf("parse json: %w", err)
+		}
+		flat = utils.Flatten("", v)
+	case "xml":
+		flat, err = parseXML(data)
+		if err != nil {
+			return Finding{}, err
+		}
+	case "yaml":
+		var raw any
+		if err := yaml.Unmarshal(data, &raw); err != nil {
+			return Finding{}, fmt.Errorf("parse yaml: %w", err)
+		}
+		flat = utils.Flatten("", normalizeYAML(raw))
+	case "toml":
+		flat = parseSimpleKV(data)
+	case "ini":
+		flat = parseINI(data)
+	default:
+		return Finding{}, fmt.Errorf("unsupported format %s", format)
+	}
+
+	params := make([]Parameter, 0, len(flat))
+	for k, v := range flat {
+		params = append(params, Parameter{
+			Key:        k,
+			Value:      v,
+			Credential: utils.ContainsCredentialKeyword(k),
+		})
+	}
+	sort.Slice(params, func(i, j int) bool { return params[i].Key < params[j].Key })
+
+	return Finding{File: path, Format: format, Params: params}, nil
+}
+
+func detectFormat(path string) string {
+	switch strings.ToLower(filepath.Ext(path)) {
+	case ".json":
+		return "json"
+	case ".xml":
+		return "xml"
+	case ".yaml", ".yml":
+		return "yaml"
+	case ".toml":
+		return "toml"
+	case ".ini", ".conf":
+		return "ini"
+	default:
+		return ""
+	}
+}
+
+func parseXML(data []byte) (map[string]string, error) {
+	decoder := xml.NewDecoder(bytes.NewReader(data))
+	decoder.CharsetReader = func(encoding string, input io.Reader) (io.Reader, error) {
+		return input, nil
+	}
+
+	flat := make(map[string]string)
+	var stack []string
+	for {
+		token, err := decoder.Token()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("parse xml: %w", err)
+		}
+		switch tok := token.(type) {
+		case xml.StartElement:
+			stack = append(stack, tok.Name.Local)
+			for _, attr := range tok.Attr {
+				key := strings.Join(append(stack, "@"+attr.Name.Local), ".")
+				flat[key] = attr.Value
+			}
+		case xml.EndElement:
+			if len(stack) > 0 {
+				stack = stack[:len(stack)-1]
+			}
+		case xml.CharData:
+			text := strings.TrimSpace(string(tok))
+			if text == "" {
+				continue
+			}
+			key := strings.Join(stack, ".")
+			flat[key] = text
+		}
+	}
+	return flat, nil
+}
+
+func parseSimpleKV(data []byte) map[string]string {
+	flat := make(map[string]string)
+	scanner := bufio.NewScanner(bytes.NewReader(data))
+	var prefix string
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
+			prefix = strings.Trim(line, "[]")
+			continue
+		}
+		parts := strings.SplitN(line, "=", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		key := strings.TrimSpace(parts[0])
+		value := strings.Trim(strings.TrimSpace(parts[1]), "\"'")
+		if prefix != "" {
+			key = prefix + "." + key
+		}
+		flat[key] = value
+	}
+	return flat
+}
+
+func normalizeYAML(v any) any {
+	switch val := v.(type) {
+	case map[string]any:
+		out := make(map[string]any, len(val))
+		for k, sub := range val {
+			out[k] = normalizeYAML(sub)
+		}
+		return out
+	case map[any]any:
+		out := make(map[string]any, len(val))
+		for k, sub := range val {
+			out[fmt.Sprint(k)] = normalizeYAML(sub)
+		}
+		return out
+	case []any:
+		for i, sub := range val {
+			val[i] = normalizeYAML(sub)
+		}
+		return val
+	default:
+		return val
+	}
+}
+
+func parseINI(data []byte) map[string]string {
+	flat := make(map[string]string)
+	scanner := bufio.NewScanner(bytes.NewReader(data))
+	var section string
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") || strings.HasPrefix(line, ";") {
+			continue
+		}
+		if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
+			section = strings.Trim(line, "[]")
+			continue
+		}
+		parts := strings.SplitN(line, "=", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		key := strings.TrimSpace(parts[0])
+		value := strings.Trim(strings.TrimSpace(parts[1]), "\"'")
+		if section != "" {
+			key = section + "." + key
+		}
+		flat[key] = value
+	}
+	return flat
+}

--- a/pkg/extractor/extractor.go
+++ b/pkg/extractor/extractor.go
@@ -1,0 +1,551 @@
+package extractor
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"firmwareanalyzer/pkg/utils"
+)
+
+// Partition describes a logical filesystem extracted from a firmware image.
+type Partition struct {
+	Name   string `json:"name"`
+	Path   string `json:"path"`
+	Type   string `json:"type"`
+	Size   int64  `json:"size"`
+	Offset int64  `json:"offset,omitempty"`
+	Notes  string `json:"notes,omitempty"`
+}
+
+// Result holds metadata about an extraction run.
+type Result struct {
+	Firmware   string      `json:"firmware"`
+	OutputDir  string      `json:"output_dir"`
+	Started    time.Time   `json:"started"`
+	Completed  time.Time   `json:"completed"`
+	Partitions []Partition `json:"partitions"`
+}
+
+// Options configure the Extractor behaviour.
+type Options struct {
+	WorkDir            string
+	PreserveTemp       bool
+	ExternalExtractors []string
+}
+
+// Extractor performs firmware extraction using built-in archive handlers and
+// optional external tooling.
+type Extractor struct {
+	opts   Options
+	logger *log.Logger
+}
+
+// New creates an Extractor with the supplied options. If logger is nil it is
+// replaced with a silent logger.
+func New(opts Options, logger *log.Logger) *Extractor {
+	if logger == nil {
+		logger = log.New(io.Discard, "extractor", log.LstdFlags)
+	}
+	if len(opts.ExternalExtractors) == 0 {
+		opts.ExternalExtractors = []string{"unblob", "binwalk"}
+	}
+	return &Extractor{opts: opts, logger: logger}
+}
+
+// Extract expands the supplied firmware image into a working directory and
+// returns metadata about any detected partitions. The function supports
+// tarballs (optionally gzip compressed), zip archives, and already extracted
+// directory trees.
+func (e *Extractor) Extract(ctx context.Context, firmwarePath string) (*Result, error) {
+	info, err := os.Stat(firmwarePath)
+	if err != nil {
+		return nil, fmt.Errorf("stat firmware: %w", err)
+	}
+
+	workDir := e.opts.WorkDir
+	if workDir == "" {
+		workDir, err = os.MkdirTemp("", "fw-extract-*")
+		if err != nil {
+			return nil, fmt.Errorf("create temp dir: %w", err)
+		}
+	} else {
+		if err := os.MkdirAll(workDir, 0o755); err != nil {
+			return nil, fmt.Errorf("create workdir: %w", err)
+		}
+		workDir, err = os.MkdirTemp(workDir, "fw-")
+		if err != nil {
+			return nil, fmt.Errorf("create nested temp dir: %w", err)
+		}
+	}
+
+	res := &Result{
+		Firmware:  firmwarePath,
+		OutputDir: workDir,
+		Started:   time.Now(),
+	}
+
+	cleanup := func() {
+		if e.opts.PreserveTemp {
+			return
+		}
+		if err != nil {
+			_ = os.RemoveAll(workDir)
+		}
+	}
+	defer cleanup()
+
+	switch {
+	case info.IsDir():
+		if err = copyDir(ctx, firmwarePath, workDir); err != nil {
+			return nil, err
+		}
+	default:
+		var usedExternal bool
+		usedExternal, err = e.tryExternal(ctx, firmwarePath, workDir)
+		if err != nil {
+			return nil, err
+		}
+		if !usedExternal {
+			ext := strings.ToLower(filepath.Ext(info.Name()))
+			switch ext {
+			case ".gz", ".tgz", ".tar":
+				if err = extractTar(ctx, firmwarePath, workDir); err != nil {
+					return nil, err
+				}
+			case ".zip":
+				if err = extractZip(ctx, firmwarePath, workDir); err != nil {
+					return nil, err
+				}
+			default:
+				return nil, fmt.Errorf("unsupported firmware format: %s", firmwarePath)
+			}
+		}
+	}
+
+	root := normalizeRoot(workDir)
+	res.OutputDir = root
+
+	var partitions []Partition
+	partitions, err = discoverPartitions(root)
+	if err != nil {
+		return nil, err
+	}
+	res.Partitions = partitions
+	res.Completed = time.Now()
+	return res, nil
+}
+
+func copyDir(ctx context.Context, src, dst string) error {
+	return filepath.WalkDir(src, func(path string, d os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		rel, err := filepath.Rel(src, path)
+		if err != nil {
+			return err
+		}
+		target := filepath.Join(dst, rel)
+		if d.IsDir() {
+			return os.MkdirAll(target, 0o755)
+		}
+
+		info, err := d.Info()
+		if err != nil {
+			return err
+		}
+
+		if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+			return err
+		}
+
+		in, err := os.Open(path)
+		if err != nil {
+			return err
+		}
+		out, err := os.OpenFile(target, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, info.Mode())
+		if err != nil {
+			in.Close()
+			return err
+		}
+		if _, err := io.Copy(out, in); err != nil {
+			out.Close()
+			in.Close()
+			return err
+		}
+		out.Close()
+		in.Close()
+		return nil
+	})
+}
+
+func extractTar(ctx context.Context, src, dst string) error {
+	file, err := os.Open(src)
+	if err != nil {
+		return fmt.Errorf("open tar: %w", err)
+	}
+	defer file.Close()
+
+	var reader io.Reader = file
+	lower := strings.ToLower(src)
+	if strings.HasSuffix(lower, ".gz") || strings.HasSuffix(lower, ".tgz") {
+		gz, err := gzip.NewReader(file)
+		if err != nil {
+			return fmt.Errorf("gzip reader: %w", err)
+		}
+		defer gz.Close()
+		reader = gz
+	}
+
+	tarReader := tar.NewReader(reader)
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		header, err := tarReader.Next()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("tar next: %w", err)
+		}
+		target := filepath.Join(dst, header.Name)
+		switch header.Typeflag {
+		case tar.TypeDir:
+			if err := os.MkdirAll(target, os.FileMode(header.Mode)); err != nil {
+				return fmt.Errorf("mkdir %s: %w", target, err)
+			}
+		case tar.TypeReg, tar.TypeRegA:
+			if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+				return err
+			}
+			out, err := os.OpenFile(target, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, os.FileMode(header.Mode))
+			if err != nil {
+				return fmt.Errorf("create %s: %w", target, err)
+			}
+			if _, err := io.Copy(out, tarReader); err != nil {
+				out.Close()
+				return fmt.Errorf("copy %s: %w", target, err)
+			}
+			out.Close()
+		}
+	}
+	return nil
+}
+
+func extractZip(ctx context.Context, src, dst string) error {
+	reader, err := zip.OpenReader(src)
+	if err != nil {
+		return fmt.Errorf("open zip: %w", err)
+	}
+	defer reader.Close()
+
+	for _, file := range reader.File {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		target := filepath.Join(dst, file.Name)
+		if file.FileInfo().IsDir() {
+			if err := os.MkdirAll(target, file.Mode()); err != nil {
+				return err
+			}
+			continue
+		}
+
+		if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+			return err
+		}
+
+		rc, err := file.Open()
+		if err != nil {
+			return err
+		}
+		out, err := os.OpenFile(target, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, file.Mode())
+		if err != nil {
+			rc.Close()
+			return err
+		}
+		if _, err := io.Copy(out, rc); err != nil {
+			out.Close()
+			rc.Close()
+			return err
+		}
+		out.Close()
+		rc.Close()
+	}
+
+	return nil
+}
+
+func (e *Extractor) tryExternal(ctx context.Context, firmwarePath, outputDir string) (bool, error) {
+	for _, tool := range e.opts.ExternalExtractors {
+		ok, err := e.runExternal(ctx, tool, firmwarePath, outputDir)
+		if err != nil {
+			if errors.Is(err, context.Canceled) {
+				return false, err
+			}
+			e.logger.Printf("external extractor %s failed: %v", tool, err)
+			continue
+		}
+		if ok {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func (e *Extractor) runExternal(ctx context.Context, tool, firmwarePath, outputDir string) (bool, error) {
+	path, err := exec.LookPath(tool)
+	if err != nil {
+		return false, nil
+	}
+	var args []string
+	switch filepath.Base(path) {
+	case "unblob":
+		args = []string{"--extract-dir", outputDir, firmwarePath}
+	case "binwalk":
+		args = []string{"--extract", "--directory", outputDir, firmwarePath}
+	default:
+		return false, fmt.Errorf("unsupported external extractor: %s", tool)
+	}
+	cmd := exec.CommandContext(ctx, path, args...)
+	cmd.Stdout = io.Discard
+	cmd.Stderr = io.Discard
+	if err := cmd.Run(); err != nil {
+		return false, fmt.Errorf("run %s: %w", tool, err)
+	}
+	return true, nil
+}
+
+func normalizeRoot(dir string) string {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return dir
+	}
+	if len(entries) != 1 {
+		return dir
+	}
+	entry := entries[0]
+	if !entry.IsDir() {
+		return dir
+	}
+	name := strings.ToLower(entry.Name())
+	if strings.Contains(name, "extract") || strings.HasSuffix(name, "-root") || strings.HasSuffix(name, "_root") {
+		return filepath.Join(dir, entry.Name())
+	}
+	return dir
+}
+
+func discoverPartitions(root string) ([]Partition, error) {
+	var parts []Partition
+	err := filepath.WalkDir(root, func(path string, d os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if path == root {
+			return nil
+		}
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			if !utils.LooksLikeRoot(path) {
+				return nil
+			}
+			info, err := d.Info()
+			if err != nil {
+				return err
+			}
+			parts = append(parts, Partition{
+				Name:  rel,
+				Path:  path,
+				Type:  "directory",
+				Size:  info.Size(),
+				Notes: "contains system directories",
+			})
+			return nil
+		}
+
+		info, err := d.Info()
+		if err != nil {
+			return err
+		}
+		partType, offset, notes, err := classifyPartition(path)
+		if err != nil {
+			return err
+		}
+		if partType == "" {
+			return nil
+		}
+		parts = append(parts, Partition{
+			Name:   rel,
+			Path:   path,
+			Type:   partType,
+			Size:   info.Size(),
+			Offset: offset,
+			Notes:  notes,
+		})
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	sort.Slice(parts, func(i, j int) bool { return parts[i].Name < parts[j].Name })
+	return parts, nil
+}
+
+func classifyPartition(path string) (string, int64, string, error) {
+	ext := strings.ToLower(filepath.Ext(path))
+	switch ext {
+	case ".squashfs", ".sqsh":
+		return "squashfs", 0, "detected via extension", nil
+	case ".ubi":
+		return "ubi", 0, "detected via extension", nil
+	case ".ext", ".ext2", ".ext3", ".ext4":
+		return "ext", 0, "detected via extension", nil
+	}
+
+	file, err := os.Open(path)
+	if err != nil {
+		return "", 0, "", fmt.Errorf("open partition: %w", err)
+	}
+	defer file.Close()
+
+	header := make([]byte, 4)
+	if _, err := io.ReadFull(file, header); err == nil {
+		switch string(header) {
+		case "hsqs", "sqsh":
+			return "squashfs", 0, "magic matched", nil
+		case "UBI#", "UBI!":
+			return "ubi", 0, "magic matched", nil
+		}
+	}
+
+	if _, err := file.Seek(0x438, io.SeekStart); err == nil {
+		var extMagic uint16
+		if err := binary.Read(file, binary.LittleEndian, &extMagic); err == nil && extMagic == 0xEF53 {
+			return "ext", 0, "superblock magic matched", nil
+		}
+	}
+
+	if ok, offset, notes, err := probeGPT(file); err != nil {
+		return "", 0, "", err
+	} else if ok {
+		return "gpt", offset, notes, nil
+	}
+
+	if ok, notes, err := probeMTD(file); err != nil {
+		return "", 0, "", err
+	} else if ok {
+		return "mtd", 0, notes, nil
+	}
+
+	return "", 0, "", nil
+}
+
+func probeGPT(file *os.File) (bool, int64, string, error) {
+	if _, err := file.Seek(0, io.SeekEnd); err != nil {
+		return false, 0, "", err
+	}
+	size, err := file.Seek(0, io.SeekCurrent)
+	if err != nil {
+		return false, 0, "", err
+	}
+	if size < 0x400 {
+		return false, 0, "", nil
+	}
+	if _, err := file.Seek(0x200, io.SeekStart); err != nil {
+		return false, 0, "", err
+	}
+	var header struct {
+		Signature           [8]byte
+		Revision            uint32
+		HeaderSize          uint32
+		CRC32               uint32
+		Reserved            uint32
+		CurrentLBA          uint64
+		BackupLBA           uint64
+		FirstUsableLBA      uint64
+		LastUsableLBA       uint64
+		DiskGUID            [16]byte
+		PartitionEntryLBA   uint64
+		NumPartitionEntries uint32
+		PartitionEntrySize  uint32
+		PartitionArrayCRC32 uint32
+	}
+	if err := binary.Read(file, binary.LittleEndian, &header); err != nil {
+		return false, 0, "", nil
+	}
+	if !bytes.Equal(header.Signature[:], []byte("EFI PART")) {
+		return false, 0, "", nil
+	}
+	entryOffset := int64(header.PartitionEntryLBA) * 512
+	if entryOffset <= 0 {
+		return true, 0, "GPT header detected", nil
+	}
+	if _, err := file.Seek(entryOffset, io.SeekStart); err != nil {
+		return true, 0, "GPT header detected", nil
+	}
+	entrySize := int64(header.PartitionEntrySize)
+	if entrySize < 32 {
+		entrySize = 128
+	}
+	entry := make([]byte, entrySize)
+	if _, err := io.ReadFull(file, entry); err != nil {
+		return true, 0, "GPT header detected", nil
+	}
+	if bytes.Equal(entry[:16], make([]byte, 16)) {
+		return true, 0, "GPT present without populated entries", nil
+	}
+	firstLBA := binary.LittleEndian.Uint64(entry[32:40])
+	lastLBA := binary.LittleEndian.Uint64(entry[40:48])
+	nameBytes := bytes.Trim(entry[56:], "\x00")
+	name := strings.TrimSpace(string(nameBytes))
+	if name == "" {
+		name = "unnamed"
+	}
+	notes := fmt.Sprintf("GPT partition %s (%d-%d)", name, firstLBA, lastLBA)
+	return true, int64(firstLBA) * 512, notes, nil
+}
+
+func probeMTD(file *os.File) (bool, string, error) {
+	if _, err := file.Seek(0, io.SeekStart); err != nil {
+		return false, "", err
+	}
+	buf := make([]byte, 64*1024)
+	n, err := file.Read(buf)
+	if err != nil && !errors.Is(err, io.EOF) {
+		return false, "", err
+	}
+	buf = buf[:n]
+	if bytes.Contains(buf, []byte("mtdparts=")) {
+		return true, "contains mtdparts definition", nil
+	}
+	return false, "", nil
+}

--- a/pkg/filesystem/filesystem.go
+++ b/pkg/filesystem/filesystem.go
@@ -1,0 +1,243 @@
+package filesystem
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"firmwareanalyzer/pkg/utils"
+)
+
+// Mount represents a filesystem image or directory detected within an
+// extracted firmware tree.
+type Mount struct {
+	ImagePath  string `json:"image_path"`
+	MountPoint string `json:"mount_point"`
+	Type       string `json:"type"`
+	Size       int64  `json:"size"`
+	Offset     int64  `json:"offset,omitempty"`
+	Notes      string `json:"notes,omitempty"`
+}
+
+// Detector provides lightweight filesystem detection heuristics for common
+// embedded formats without performing privileged mounts.
+type Detector struct {
+	logger   *log.Logger
+	maxProbe int64
+}
+
+// NewDetector returns a Detector that probes up to 4MiB of each candidate file.
+func NewDetector(logger *log.Logger) *Detector {
+	if logger == nil {
+		logger = log.New(io.Discard, "filesystem", log.LstdFlags)
+	}
+	return &Detector{logger: logger, maxProbe: 4 << 20}
+}
+
+// Detect walks the supplied root directory looking for filesystem images.
+// Directories are treated as already extracted mounts and files are inspected
+// for SquashFS, UBI and ext4 signatures.
+func (d *Detector) Detect(ctx context.Context, root string) ([]Mount, error) {
+	var mounts []Mount
+	err := filepath.WalkDir(root, func(path string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+		if path == root {
+			return nil
+		}
+		if entry.IsDir() {
+			if !utils.LooksLikeRoot(path) {
+				return nil
+			}
+			info, err := entry.Info()
+			if err != nil {
+				return err
+			}
+			mounts = append(mounts, Mount{
+				ImagePath:  path,
+				MountPoint: path,
+				Type:       "directory",
+				Size:       info.Size(),
+				Notes:      "contains system directories",
+			})
+			return nil
+		}
+
+		info, err := entry.Info()
+		if err != nil {
+			return err
+		}
+		mntType, notes, offset, err := d.classify(path)
+		if err != nil {
+			return err
+		}
+		if mntType == "" {
+			return nil
+		}
+		mounts = append(mounts, Mount{
+			ImagePath:  path,
+			MountPoint: "",
+			Type:       mntType,
+			Size:       info.Size(),
+			Offset:     offset,
+			Notes:      notes,
+		})
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	sort.Slice(mounts, func(i, j int) bool { return mounts[i].ImagePath < mounts[j].ImagePath })
+	return mounts, nil
+}
+
+func (d *Detector) classify(path string) (string, string, int64, error) {
+	ext := strings.ToLower(filepath.Ext(path))
+	switch ext {
+	case ".squashfs", ".sqsh":
+		return "squashfs", "detected via file extension", 0, nil
+	case ".ubi":
+		return "ubi", "detected via file extension", 0, nil
+	case ".ext", ".ext2", ".ext3", ".ext4":
+		return "ext", "detected via file extension", 0, nil
+	}
+
+	file, err := os.Open(path)
+	if err != nil {
+		return "", "", 0, fmt.Errorf("open image: %w", err)
+	}
+	defer file.Close()
+
+	magic := make([]byte, 4)
+	if _, err := io.ReadFull(file, magic); err != nil {
+		return "", "", 0, nil
+	}
+
+	switch {
+	case string(magic) == "hsqs" || string(magic) == "sqsh":
+		return "squashfs", "magic matched", 0, nil
+	case string(magic) == "UBI#" || string(magic) == "UBI!":
+		return "ubi", "magic matched", 0, nil
+	}
+
+	// ext4 magic resides at offset 0x438
+	if _, err := file.Seek(0x438, io.SeekStart); err == nil {
+		var extMagic uint16
+		if err := binary.Read(file, binary.LittleEndian, &extMagic); err == nil && extMagic == 0xEF53 {
+			return "ext", "magic matched", 0, nil
+		}
+	}
+	if ok, offset, notes, err := probeGPT(file); err != nil {
+		return "", "", 0, err
+	} else if ok {
+		return "gpt", notes, offset, nil
+	}
+	if ok, notes, err := probeMTD(file, d.maxProbe); err != nil {
+		return "", "", 0, err
+	} else if ok {
+		return "mtd", notes, 0, nil
+	}
+	return "", "", 0, nil
+}
+
+func probeGPT(file *os.File) (bool, int64, string, error) {
+	if _, err := file.Seek(0, io.SeekEnd); err != nil {
+		return false, 0, "", err
+	}
+	size, err := file.Seek(0, io.SeekCurrent)
+	if err != nil {
+		return false, 0, "", err
+	}
+	if size < 0x400 {
+		return false, 0, "", nil
+	}
+	if _, err := file.Seek(0x200, io.SeekStart); err != nil {
+		return false, 0, "", err
+	}
+	var header struct {
+		Signature           [8]byte
+		Revision            uint32
+		HeaderSize          uint32
+		CRC32               uint32
+		Reserved            uint32
+		CurrentLBA          uint64
+		BackupLBA           uint64
+		FirstUsableLBA      uint64
+		LastUsableLBA       uint64
+		DiskGUID            [16]byte
+		PartitionEntryLBA   uint64
+		NumPartitionEntries uint32
+		PartitionEntrySize  uint32
+		PartitionArrayCRC32 uint32
+	}
+	if err := binary.Read(file, binary.LittleEndian, &header); err != nil {
+		return false, 0, "", nil
+	}
+	if !bytes.Equal(header.Signature[:], []byte("EFI PART")) {
+		return false, 0, "", nil
+	}
+	entryOffset := int64(header.PartitionEntryLBA) * 512
+	if entryOffset <= 0 {
+		return true, 0, "GPT header detected", nil
+	}
+	if _, err := file.Seek(entryOffset, io.SeekStart); err != nil {
+		return true, 0, "GPT header detected", nil
+	}
+	entrySize := int64(header.PartitionEntrySize)
+	if entrySize < 32 {
+		entrySize = 128
+	}
+	entry := make([]byte, entrySize)
+	if _, err := io.ReadFull(file, entry); err != nil {
+		return true, 0, "GPT header detected", nil
+	}
+	if len(entry) < 56 {
+		return true, 0, "GPT header detected", nil
+	}
+	if bytes.Equal(entry[:16], make([]byte, 16)) {
+		return true, 0, "GPT present without populated entries", nil
+	}
+	firstLBA := binary.LittleEndian.Uint64(entry[32:40])
+	lastLBA := binary.LittleEndian.Uint64(entry[40:48])
+	nameBytes := bytes.Trim(entry[56:], "\x00")
+	name := strings.TrimSpace(string(nameBytes))
+	if name == "" {
+		name = "unnamed"
+	}
+	notes := fmt.Sprintf("GPT partition %s (%d-%d)", name, firstLBA, lastLBA)
+	return true, int64(firstLBA) * 512, notes, nil
+}
+
+func probeMTD(file *os.File, max int64) (bool, string, error) {
+	if _, err := file.Seek(0, io.SeekStart); err != nil {
+		return false, "", err
+	}
+	bufSize := max
+	if bufSize <= 0 || bufSize > 64*1024 {
+		bufSize = 64 * 1024
+	}
+	buf := make([]byte, bufSize)
+	n, err := file.Read(buf)
+	if err != nil && !errors.Is(err, io.EOF) {
+		return false, "", err
+	}
+	buf = buf[:n]
+	if bytes.Contains(buf, []byte("mtdparts=")) {
+		return true, "contains mtdparts definition", nil
+	}
+	return false, "", nil
+}

--- a/pkg/report/report.go
+++ b/pkg/report/report.go
@@ -1,0 +1,214 @@
+package report
+
+import (
+	"encoding/json"
+	"fmt"
+	"html/template"
+	"io"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"firmwareanalyzer/pkg/binaryinspector"
+	"firmwareanalyzer/pkg/configparser"
+	"firmwareanalyzer/pkg/extractor"
+	"firmwareanalyzer/pkg/filesystem"
+	"firmwareanalyzer/pkg/secrets"
+	"firmwareanalyzer/pkg/service"
+)
+
+// Summary aggregates analysis results for rendering.
+type Summary struct {
+	Firmware    string
+	Extraction  *extractor.Result
+	FileSystems []filesystem.Mount
+	Configs     []configparser.Finding
+	Services    []service.Service
+	Secrets     []secrets.Finding
+	Binaries    []binaryinspector.Result
+}
+
+// Generator renders Markdown and HTML reports.
+type Generator struct {
+	logger *log.Logger
+}
+
+// NewGenerator returns a generator that discards log output when logger is nil.
+func NewGenerator(logger *log.Logger) *Generator {
+	if logger == nil {
+		logger = log.New(io.Discard, "report", log.LstdFlags)
+	}
+	return &Generator{logger: logger}
+}
+
+// Markdown produces a Markdown report summarising the supplied analysis.
+func (g *Generator) Markdown(summary Summary) string {
+	var builder strings.Builder
+	builder.WriteString("# Drone Firmware Analyzer Report\n\n")
+	builder.WriteString(fmt.Sprintf("**Firmware:** %s\n\n", summary.Firmware))
+
+	if summary.Extraction != nil {
+		builder.WriteString("## Extraction\n")
+		builder.WriteString(fmt.Sprintf("Output directory: `%s`\n\n", summary.Extraction.OutputDir))
+		if len(summary.Extraction.Partitions) > 0 {
+			builder.WriteString("| Name | Type | Size (bytes) | Offset | Notes | Path |\n")
+			builder.WriteString("| --- | --- | --- | --- | --- | --- |\n")
+			for _, part := range summary.Extraction.Partitions {
+				offset := "-"
+				if part.Offset > 0 {
+					offset = fmt.Sprintf("%d", part.Offset)
+				}
+				notes := part.Notes
+				if notes == "" {
+					notes = "-"
+				}
+				builder.WriteString(fmt.Sprintf("| %s | %s | %d | %s | %s | %s |\n", part.Name, part.Type, part.Size, offset, notes, part.Path))
+			}
+			builder.WriteString("\n")
+		}
+	}
+
+	if len(summary.FileSystems) > 0 {
+		builder.WriteString("## Filesystems\n")
+		builder.WriteString("| Image | Type | Size (bytes) | Offset | Notes |\n")
+		builder.WriteString("| --- | --- | --- | --- | --- |\n")
+		for _, fs := range summary.FileSystems {
+			offset := "-"
+			if fs.Offset > 0 {
+				offset = fmt.Sprintf("%d", fs.Offset)
+			}
+			notes := fs.Notes
+			if notes == "" {
+				notes = "-"
+			}
+			builder.WriteString(fmt.Sprintf("| %s | %s | %d | %s | %s |\n", fs.ImagePath, fs.Type, fs.Size, offset, notes))
+		}
+		builder.WriteString("\n")
+	}
+
+	if len(summary.Configs) > 0 {
+		builder.WriteString("## Configuration Findings\n")
+		for _, cfg := range summary.Configs {
+			builder.WriteString(fmt.Sprintf("### %s (%s)\n", cfg.File, strings.ToUpper(cfg.Format)))
+			builder.WriteString("| Key | Value | Credential? |\n")
+			builder.WriteString("| --- | --- | --- |\n")
+			for _, param := range cfg.Params {
+				cred := ""
+				if param.Credential {
+					cred = "⚠️"
+				}
+				builder.WriteString(fmt.Sprintf("| %s | %s | %s |\n", param.Key, param.Value, cred))
+			}
+			builder.WriteString("\n")
+		}
+	}
+
+	if len(summary.Services) > 0 {
+		builder.WriteString("## Services\n")
+		builder.WriteString("| Name | Type | Path | Provides |\n")
+		builder.WriteString("| --- | --- | --- | --- |\n")
+		for _, svc := range summary.Services {
+			builder.WriteString(fmt.Sprintf("| %s | %s | %s | %s |\n", svc.Name, svc.Type, svc.Path, strings.Join(svc.Provides, ", ")))
+		}
+		builder.WriteString("\n")
+	}
+
+	if len(summary.Secrets) > 0 {
+		builder.WriteString("## Secrets\n")
+		builder.WriteString("| File | Line | Rule | Match | Entropy |\n")
+		builder.WriteString("| --- | --- | --- | --- | --- |\n")
+		for _, sec := range summary.Secrets {
+			builder.WriteString(fmt.Sprintf("| %s | %d | %s | `%s` | %.2f |\n", sec.File, sec.Line, sec.Rule, sec.Match, sec.Entropy))
+		}
+		builder.WriteString("\n")
+	}
+
+	if len(summary.Binaries) > 0 {
+		builder.WriteString("## Binary Protections\n")
+		builder.WriteString(binaryinspector.CollectMarkdownTable(summary.Binaries))
+		builder.WriteString("\n")
+	}
+
+	return builder.String()
+}
+
+// HTML renders a minimal HTML document embedding the Markdown content.
+func (g *Generator) HTML(summary Summary) (string, error) {
+	return g.htmlFromMarkdown(g.Markdown(summary))
+}
+
+// Formats declares which report artefacts should be written.
+type Formats struct {
+	Markdown bool
+	HTML     bool
+	JSON     bool
+}
+
+// DefaultFormats enables all report formats.
+var DefaultFormats = Formats{Markdown: true, HTML: true, JSON: true}
+
+// Paths describes the artefacts written to disk.
+type Paths struct {
+	Markdown string
+	HTML     string
+	JSON     string
+}
+
+// WriteFiles writes selected report formats to the specified directory.
+func (g *Generator) WriteFiles(summary Summary, outputDir string, formats Formats) (Paths, error) {
+	if err := os.MkdirAll(outputDir, 0o755); err != nil {
+		return Paths{}, err
+	}
+	if !formats.Markdown && !formats.HTML && !formats.JSON {
+		formats = DefaultFormats
+	}
+	var paths Paths
+	var md string
+	if formats.Markdown || formats.HTML {
+		md = g.Markdown(summary)
+	}
+	if formats.Markdown {
+		mdPath := filepath.Join(outputDir, "report.md")
+		if err := os.WriteFile(mdPath, []byte(md), 0o644); err != nil {
+			return Paths{}, err
+		}
+		paths.Markdown = mdPath
+	}
+	if formats.HTML {
+		html, err := g.htmlFromMarkdown(md)
+		if err != nil {
+			return Paths{}, err
+		}
+		htmlPath := filepath.Join(outputDir, "report.html")
+		if err := os.WriteFile(htmlPath, []byte(html), 0o644); err != nil {
+			return Paths{}, err
+		}
+		paths.HTML = htmlPath
+	}
+	if formats.JSON {
+		data, err := json.MarshalIndent(summary, "", "  ")
+		if err != nil {
+			return Paths{}, err
+		}
+		jsonPath := filepath.Join(outputDir, "report.json")
+		if err := os.WriteFile(jsonPath, data, 0o644); err != nil {
+			return Paths{}, err
+		}
+		paths.JSON = jsonPath
+	}
+	return paths, nil
+}
+
+func (g *Generator) htmlFromMarkdown(md string) (string, error) {
+	tmpl := `<html><head><meta charset="utf-8"><title>Drone Firmware Analyzer Report</title></head><body><pre>{{.}}</pre></body></html>`
+	t, err := template.New("report").Parse(tmpl)
+	if err != nil {
+		return "", err
+	}
+	var builder strings.Builder
+	if err := t.Execute(&builder, md); err != nil {
+		return "", err
+	}
+	return builder.String(), nil
+}

--- a/pkg/secrets/secrets.go
+++ b/pkg/secrets/secrets.go
@@ -1,0 +1,213 @@
+package secrets
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+
+	"firmwareanalyzer/pkg/utils"
+)
+
+// Finding represents a potential secret discovered within a file.
+type Finding struct {
+	File    string  `json:"file"`
+	Line    int     `json:"line"`
+	Match   string  `json:"match"`
+	Rule    string  `json:"rule"`
+	Entropy float64 `json:"entropy"`
+}
+
+// Scanner searches firmware trees for credentials using regex and entropy
+// heuristics. An allow-list can be provided to reduce false positives.
+type Scanner struct {
+	logger      *log.Logger
+	allowExact  map[string]struct{}
+	allowRules  map[string][]string
+	patterns    []pattern
+	minEntropy  float64
+	maxFileSize int64
+}
+
+type pattern struct {
+	name       string
+	re         *regexp.Regexp
+	minEntropy float64
+	minLength  int
+}
+
+// ScannerOptions customise the behaviour of the secret scanner.
+type ScannerOptions struct {
+	AllowExact        []string
+	AllowRulePatterns map[string][]string
+	MinEntropy        float64
+	MaxFileSize       int64
+}
+
+// NewScanner creates a scanner configured with sensible defaults.
+func NewScanner(logger *log.Logger, allowList []string) *Scanner {
+	return NewScannerWithOptions(logger, ScannerOptions{AllowExact: allowList})
+}
+
+// NewScannerWithOptions builds a scanner using custom thresholds and allow-lists.
+func NewScannerWithOptions(logger *log.Logger, opts ScannerOptions) *Scanner {
+	if logger == nil {
+		logger = log.New(io.Discard, "secrets", log.LstdFlags)
+	}
+	allowExact := make(map[string]struct{}, len(opts.AllowExact))
+	for _, item := range opts.AllowExact {
+		allowExact[item] = struct{}{}
+	}
+	patterns := []pattern{
+		{name: "AWS Access Key", re: regexp.MustCompile(`AKIA[0-9A-Z]{16}`)},
+		{name: "Generic API Key", re: regexp.MustCompile(`[A-Za-z0-9_\-]{24,}`), minEntropy: 3.5, minLength: 24},
+		{name: "JWT", re: regexp.MustCompile(`eyJ[\w-]{20,}\.[\w-]{20,}\.[\w-]{10,}`), minEntropy: 3.0},
+		{name: "Slack Token", re: regexp.MustCompile(`xox[baprs]-[A-Za-z0-9-]{10,}`), minEntropy: 3.0},
+		{name: "Private Key", re: regexp.MustCompile(`-----BEGIN [A-Z ]+PRIVATE KEY-----`), minEntropy: 0, minLength: 0},
+		{name: "SSH Authorized Key", re: regexp.MustCompile(`ssh-(rsa|ed25519|dss) [A-Za-z0-9+/=]+`), minEntropy: 2.5},
+		{name: "Password Assignment", re: regexp.MustCompile(`(?i)(password|passwd|secret)\s*=\s*['\"]?([^'\"\s]+)`), minEntropy: 0},
+	}
+	minEntropy := opts.MinEntropy
+	if minEntropy == 0 {
+		minEntropy = 3.5
+	}
+	maxFile := opts.MaxFileSize
+	if maxFile == 0 {
+		maxFile = 1 << 20
+	}
+	return &Scanner{
+		logger:      logger,
+		allowExact:  allowExact,
+		allowRules:  opts.AllowRulePatterns,
+		patterns:    patterns,
+		minEntropy:  minEntropy,
+		maxFileSize: maxFile,
+	}
+}
+
+// Scan walks the root directory, scanning text files and reporting any
+// discoveries that meet entropy requirements and are not allow-listed.
+func (s *Scanner) Scan(ctx context.Context, root string) ([]Finding, error) {
+	var findings []Finding
+	err := filepath.WalkDir(root, func(path string, d os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.IsDir() {
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+		info, err := d.Info()
+		if err != nil {
+			return err
+		}
+		if info.Size() > s.maxFileSize {
+			return nil
+		}
+		fileFindings, err := s.scanFile(path)
+		if err != nil {
+			return err
+		}
+		findings = append(findings, fileFindings...)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	sort.Slice(findings, func(i, j int) bool {
+		if findings[i].File == findings[j].File {
+			return findings[i].Line < findings[j].Line
+		}
+		return findings[i].File < findings[j].File
+	})
+	return findings, nil
+}
+
+func (s *Scanner) scanFile(path string) ([]Finding, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read file: %w", err)
+	}
+	if !utils.LooksLikeText(data) {
+		return nil, nil
+	}
+
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	var findings []Finding
+	scanner := bufio.NewScanner(file)
+	lineNum := 0
+	for scanner.Scan() {
+		lineNum++
+		line := scanner.Text()
+		for _, pat := range s.patterns {
+			matches := pat.re.FindAllStringSubmatch(line, -1)
+			if len(matches) == 0 {
+				continue
+			}
+			for _, match := range matches {
+				candidate := match[0]
+				if _, ok := s.allowExact[candidate]; ok {
+					continue
+				}
+				if s.isRuleSuppressed(pat.name, candidate) {
+					continue
+				}
+				entropy := utils.ShannonEntropy(candidate)
+				threshold := s.minEntropy
+				if pat.minEntropy > 0 {
+					threshold = pat.minEntropy
+				}
+				if pat.minLength > 0 && len(candidate) < pat.minLength {
+					continue
+				}
+				if utils.ContainsCredentialKeyword(line) || entropy >= threshold {
+					findings = append(findings, Finding{
+						File:    path,
+						Line:    lineNum,
+						Match:   candidate,
+						Rule:    pat.name,
+						Entropy: entropy,
+					})
+				}
+			}
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	return findings, nil
+}
+
+func (s *Scanner) isRuleSuppressed(rule, candidate string) bool {
+	if len(s.allowRules) == 0 {
+		return false
+	}
+	patterns, ok := s.allowRules[rule]
+	if !ok {
+		return false
+	}
+	for _, pattern := range patterns {
+		if ok, _ := filepath.Match(pattern, candidate); ok {
+			return true
+		}
+		if strings.HasPrefix(candidate, pattern) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -1,0 +1,172 @@
+package service
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// Service represents an init component discovered inside a firmware image.
+type Service struct {
+	Name     string   `json:"name"`
+	Path     string   `json:"path"`
+	Type     string   `json:"type"`
+	Provides []string `json:"provides,omitempty"`
+}
+
+// Detector scans extracted filesystem trees for init systems, rc scripts and
+// unit definitions to help build a runtime service inventory.
+type Detector struct {
+	logger *log.Logger
+}
+
+// NewDetector constructs a Detector. When logger is nil, logging is discarded.
+func NewDetector(logger *log.Logger) *Detector {
+	if logger == nil {
+		logger = log.New(io.Discard, "service", log.LstdFlags)
+	}
+	return &Detector{logger: logger}
+}
+
+// Detect searches for SysV init scripts (etc/init.d), BusyBox rc directories,
+// and systemd unit files within the provided root.
+func (d *Detector) Detect(ctx context.Context, root string) ([]Service, error) {
+	var services []Service
+
+	visit := func(dir string, handler func(string, os.DirEntry) error) error {
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			if os.IsNotExist(err) {
+				return nil
+			}
+			return err
+		}
+		for _, entry := range entries {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			default:
+			}
+			if err := handler(filepath.Join(dir, entry.Name()), entry); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
+	sysvDirs := []string{
+		filepath.Join(root, "etc", "init.d"),
+		filepath.Join(root, "etc", "rc.d"),
+	}
+	for _, dir := range sysvDirs {
+		err := visit(dir, func(path string, entry os.DirEntry) error {
+			if entry.IsDir() {
+				return nil
+			}
+			info, err := entry.Info()
+			if err != nil {
+				return err
+			}
+			if info.Mode()&0o111 == 0 {
+				return nil
+			}
+			services = append(services, Service{
+				Name: entry.Name(),
+				Path: path,
+				Type: "sysvinit",
+			})
+			return nil
+		})
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	rcDirs := []string{
+		filepath.Join(root, "etc", "rc.d"),
+		filepath.Join(root, "etc", "init.d"),
+	}
+	for _, dir := range rcDirs {
+		err := visit(dir, func(path string, entry os.DirEntry) error {
+			if entry.IsDir() || strings.HasPrefix(entry.Name(), ".") {
+				return nil
+			}
+			if strings.HasPrefix(entry.Name(), "S") || strings.HasPrefix(entry.Name(), "K") {
+				services = append(services, Service{
+					Name: entry.Name(),
+					Path: path,
+					Type: "busybox-rc",
+				})
+			}
+			return nil
+		})
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	unitDirs := []string{
+		filepath.Join(root, "lib", "systemd", "system"),
+		filepath.Join(root, "etc", "systemd", "system"),
+	}
+	for _, dir := range unitDirs {
+		err := visit(dir, func(path string, entry os.DirEntry) error {
+			if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".service") {
+				return nil
+			}
+			provides, err := parseProvides(path)
+			if err != nil {
+				return err
+			}
+			services = append(services, Service{
+				Name:     strings.TrimSuffix(entry.Name(), ".service"),
+				Path:     path,
+				Type:     "systemd",
+				Provides: provides,
+			})
+			return nil
+		})
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return services, nil
+}
+
+func parseProvides(path string) ([]string, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("open unit: %w", err)
+	}
+	defer file.Close()
+
+	var provides []string
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if strings.HasPrefix(line, "#") || line == "" {
+			continue
+		}
+		lower := strings.ToLower(line)
+		if strings.HasPrefix(lower, "provides=") {
+			parts := strings.SplitN(line, "=", 2)
+			if len(parts) != 2 {
+				continue
+			}
+			value := strings.Trim(parts[1], "\"'")
+			provides = append(provides, strings.FieldsFunc(value, func(r rune) bool {
+				return r == ' ' || r == ','
+			})...)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	return provides, nil
+}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -1,0 +1,145 @@
+package utils
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+	"unicode/utf8"
+)
+
+// Flatten walks arbitrarily nested data structures (maps, slices, arrays)
+// and returns a map keyed by dot-separated paths with stringified values.
+// It is primarily used by the configuration parser to expose nested settings
+// in a uniform representation for downstream modules.
+func Flatten(prefix string, value any) map[string]string {
+	out := make(map[string]string)
+	flattenInto(out, prefix, value)
+	return out
+}
+
+func flattenInto(out map[string]string, prefix string, value any) {
+	switch v := value.(type) {
+	case map[string]interface{}:
+		keys := make([]string, 0, len(v))
+		for k := range v {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			next := k
+			if prefix != "" {
+				next = prefix + "." + k
+			}
+			flattenInto(out, next, v[k])
+		}
+	case []interface{}:
+		for idx, item := range v {
+			next := prefix + "[" + strconv.Itoa(idx) + "]"
+			flattenInto(out, next, item)
+		}
+	case json.Number:
+		out[prefix] = v.String()
+	case string:
+		out[prefix] = v
+	case fmt.Stringer:
+		out[prefix] = v.String()
+	case nil:
+		out[prefix] = ""
+	default:
+		out[prefix] = fmt.Sprint(v)
+	}
+}
+
+// ContainsCredentialKeyword reports whether the provided key path appears to
+// reference a credential. This is a heuristic used by both the configuration
+// parser and secret scanner to prioritise findings.
+func ContainsCredentialKeyword(key string) bool {
+	lowered := strings.ToLower(key)
+	keywords := []string{"pass", "secret", "token", "key", "auth", "cred"}
+	for _, kw := range keywords {
+		if strings.Contains(lowered, kw) {
+			return true
+		}
+	}
+	return false
+}
+
+// ShannonEntropy computes the Shannon entropy in bits of the supplied text.
+// High entropy strings are likely to be randomly generated secrets such as
+// API tokens. The function operates on runes to better support UTF-8 input.
+func ShannonEntropy(text string) float64 {
+	if text == "" {
+		return 0
+	}
+	freq := make(map[rune]int)
+	total := 0
+	for _, r := range text {
+		freq[r]++
+		total++
+	}
+	entropy := 0.0
+	for _, count := range freq {
+		p := float64(count) / float64(total)
+		entropy -= p * math.Log2(p)
+	}
+	return entropy
+}
+
+// LooksLikeText checks whether a byte slice appears to be text by verifying
+// it does not contain excessive NUL bytes and that it is valid UTF-8.
+func LooksLikeText(data []byte) bool {
+	if len(data) == 0 {
+		return true
+	}
+	const maxNullRatio = 0.2
+	nulls := 0
+	for _, b := range data {
+		if b == 0 {
+			nulls++
+		}
+	}
+	if float64(nulls)/float64(len(data)) > maxNullRatio {
+		return false
+	}
+	return utf8.Valid(data)
+}
+
+// LooksLikeRoot inspects the immediate children of a directory to determine
+// whether it resembles a mounted root filesystem. It looks for common
+// top-level directories (etc, bin, sbin, usr) and returns true when at least
+// two markers are present.
+func LooksLikeRoot(path string) bool {
+	entries, err := os.ReadDir(path)
+	if err != nil {
+		return false
+	}
+	markers := map[string]struct{}{
+		"etc":  {},
+		"bin":  {},
+		"sbin": {},
+		"usr":  {},
+		"root": {},
+	}
+	matches := 0
+	for i, entry := range entries {
+		if i >= 64 {
+			break
+		}
+		name := strings.ToLower(entry.Name())
+		if entry.IsDir() {
+			if _, ok := markers[name]; ok {
+				matches++
+			}
+		} else if strings.HasSuffix(name, "fstab") {
+			matches++
+		}
+		if matches >= 2 {
+			return true
+		}
+	}
+	return false
+}

--- a/tests/binaryinspector_test.go
+++ b/tests/binaryinspector_test.go
@@ -1,0 +1,71 @@
+package tests
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"firmwareanalyzer/pkg/binaryinspector"
+)
+
+func TestInspectDetectsELFBinary(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	src := filepath.Join(tmp, "main.go")
+	if err := os.WriteFile(src, []byte("package main\nfunc main(){}\n"), 0o644); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+
+	binPath := filepath.Join(tmp, "firmware")
+	cmd := exec.Command("go", "build", "-o", binPath, src)
+	cmd.Env = append(os.Environ(), "GOOS=linux", "GOARCH=amd64")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("build test binary: %v, output: %s", err, out)
+	}
+
+	inspector := binaryinspector.NewInspector(nil)
+	results, err := inspector.Inspect(context.Background(), tmp)
+	if err != nil {
+		t.Fatalf("inspect: %v", err)
+	}
+
+	var found bool
+	for _, res := range results {
+		if res.Path == binPath {
+			found = true
+			if res.Err != "" {
+				t.Fatalf("unexpected error in result: %s", res.Err)
+			}
+			if res.Architecture == "" {
+				t.Fatalf("architecture not detected: %+v", res)
+			}
+		}
+	}
+
+	if !found {
+		t.Fatalf("expected to find binary at %s", binPath)
+	}
+}
+
+func TestCollectMarkdownTable(t *testing.T) {
+	results := []binaryinspector.Result{{
+		Path:         "/tmp/bin",
+		Type:         "ET_DYN",
+		Architecture: "EM_X86_64",
+		RELRO:        binaryinspector.RELROFull,
+		NXEnabled:    true,
+		PIEEnabled:   true,
+		Stripped:     false,
+	}}
+
+	table := binaryinspector.CollectMarkdownTable(results)
+	if table == "" {
+		t.Fatal("expected non-empty table")
+	}
+	if got, want := table[:1], "|"; got != want {
+		t.Fatalf("table must start with '|' got %q", got)
+	}
+}

--- a/tests/configparser_test.go
+++ b/tests/configparser_test.go
@@ -1,0 +1,59 @@
+package tests
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"firmwareanalyzer/pkg/configparser"
+)
+
+func TestConfigParserParsesMultipleFormats(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	jsonPath := filepath.Join(root, "settings.json")
+	if err := os.WriteFile(jsonPath, []byte(`{"db":{"user":"root","password":"toor"}}`), 0o644); err != nil {
+		t.Fatalf("write json: %v", err)
+	}
+	xmlPath := filepath.Join(root, "config.xml")
+	if err := os.WriteFile(xmlPath, []byte(`<config><api token="abc123">value</api></config>`), 0o644); err != nil {
+		t.Fatalf("write xml: %v", err)
+	}
+	tomlPath := filepath.Join(root, "app.toml")
+	if err := os.WriteFile(tomlPath, []byte("[auth]\nkey = \"abcdef\"\n"), 0o644); err != nil {
+		t.Fatalf("write toml: %v", err)
+	}
+	iniPath := filepath.Join(root, "network.ini")
+	if err := os.WriteFile(iniPath, []byte("[wifi]\npassword=secret\n"), 0o644); err != nil {
+		t.Fatalf("write ini: %v", err)
+	}
+	yamlPath := filepath.Join(root, "drone.yaml")
+	yamlContent := "credentials:\n  token: abcdef123456\n  endpoints:\n    - https://example\n"
+	if err := os.WriteFile(yamlPath, []byte(yamlContent), 0o644); err != nil {
+		t.Fatalf("write yaml: %v", err)
+	}
+
+	parser := configparser.NewParser(nil)
+	findings, err := parser.Parse(context.Background(), root)
+	if err != nil {
+		t.Fatalf("parse configs: %v", err)
+	}
+
+	if len(findings) != 5 {
+		t.Fatalf("expected 5 findings, got %d", len(findings))
+	}
+
+	var credentialCount int
+	for _, finding := range findings {
+		for _, param := range finding.Params {
+			if param.Credential {
+				credentialCount++
+			}
+		}
+	}
+	if credentialCount == 0 {
+		t.Fatalf("expected credential heuristics to trigger")
+	}
+}

--- a/tests/extractor_test.go
+++ b/tests/extractor_test.go
@@ -1,0 +1,112 @@
+package tests
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"firmwareanalyzer/pkg/extractor"
+)
+
+func TestExtractorHandlesTarGz(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	firmwarePath := filepath.Join(tmp, "firmware.tgz")
+
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+	contents := map[string]string{
+		"etc/config.ini": "user=admin\npassword=secret\n",
+		"bin/app":        "#!/bin/sh\necho hi\n",
+	}
+	for name, data := range contents {
+		if err := tw.WriteHeader(&tar.Header{Name: name, Mode: 0o755, Size: int64(len(data))}); err != nil {
+			t.Fatalf("write header: %v", err)
+		}
+		if _, err := tw.Write([]byte(data)); err != nil {
+			t.Fatalf("write data: %v", err)
+		}
+	}
+	squash := append([]byte("hsqs"), bytes.Repeat([]byte{0}, 64)...)
+	if err := tw.WriteHeader(&tar.Header{Name: "rootfs.squashfs", Mode: 0o644, Size: int64(len(squash))}); err != nil {
+		t.Fatalf("write squash header: %v", err)
+	}
+	if _, err := tw.Write(squash); err != nil {
+		t.Fatalf("write squash data: %v", err)
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatalf("close tar: %v", err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatalf("close gzip: %v", err)
+	}
+	if err := os.WriteFile(firmwarePath, buf.Bytes(), 0o644); err != nil {
+		t.Fatalf("write firmware: %v", err)
+	}
+
+	ext := extractor.New(extractor.Options{}, nil)
+	result, err := ext.Extract(context.Background(), firmwarePath)
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+
+	for name := range contents {
+		if _, err := os.Stat(filepath.Join(result.OutputDir, name)); err != nil {
+			t.Fatalf("expected extracted file %s: %v", name, err)
+		}
+	}
+	if len(result.Partitions) == 0 {
+		t.Fatalf("expected partition metadata, got %#v", result.Partitions)
+	}
+	var sawSquash bool
+	for _, part := range result.Partitions {
+		if part.Type == "squashfs" && strings.HasSuffix(part.Path, "rootfs.squashfs") {
+			sawSquash = part.Notes != ""
+		}
+	}
+	if !sawSquash {
+		t.Fatalf("expected squashfs partition with notes, got %#v", result.Partitions)
+	}
+}
+
+func TestExtractorNormalizesSingleDirectoryRoot(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	firmwarePath := filepath.Join(tmp, "firmware.tar")
+
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	if err := tw.WriteHeader(&tar.Header{Name: "squashfs-root/", Mode: 0o755, Typeflag: tar.TypeDir}); err != nil {
+		t.Fatalf("write dir header: %v", err)
+	}
+	data := []byte("root:x:0:0:root:/root:/bin/sh\n")
+	if err := tw.WriteHeader(&tar.Header{Name: "squashfs-root/etc/passwd", Mode: 0o644, Size: int64(len(data))}); err != nil {
+		t.Fatalf("write file header: %v", err)
+	}
+	if _, err := tw.Write(data); err != nil {
+		t.Fatalf("write data: %v", err)
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatalf("close tar: %v", err)
+	}
+	if err := os.WriteFile(firmwarePath, buf.Bytes(), 0o644); err != nil {
+		t.Fatalf("write firmware: %v", err)
+	}
+
+	ext := extractor.New(extractor.Options{}, nil)
+	result, err := ext.Extract(context.Background(), firmwarePath)
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	if !strings.HasSuffix(result.OutputDir, "squashfs-root") {
+		t.Fatalf("expected normalized root, got %s", result.OutputDir)
+	}
+}

--- a/tests/filesystem_test.go
+++ b/tests/filesystem_test.go
@@ -1,0 +1,105 @@
+package tests
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"firmwareanalyzer/pkg/filesystem"
+)
+
+func TestFilesystemDetectorRecognisesMagic(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	squash := filepath.Join(root, "rootfs.squashfs")
+	if err := os.WriteFile(squash, []byte("hsqs"), 0o644); err != nil {
+		t.Fatalf("write squashfs: %v", err)
+	}
+
+	detector := filesystem.NewDetector(nil)
+	mounts, err := detector.Detect(context.Background(), root)
+	if err != nil {
+		t.Fatalf("detect: %v", err)
+	}
+
+	var found bool
+	for _, mnt := range mounts {
+		if mnt.ImagePath == squash && mnt.Type == "squashfs" {
+			if mnt.Offset != 0 {
+				t.Fatalf("expected zero offset for standalone squashfs, got %d", mnt.Offset)
+			}
+			if mnt.Notes == "" {
+				t.Fatalf("expected notes for squashfs mount")
+			}
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected squashfs mount in %#v", mounts)
+	}
+}
+
+func TestFilesystemDetectorDetectsLikelyRootDirectories(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	nestedRoot := filepath.Join(root, "img", "rootfs")
+	if err := os.MkdirAll(filepath.Join(nestedRoot, "etc"), 0o755); err != nil {
+		t.Fatalf("mkdir etc: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(nestedRoot, "bin"), 0o755); err != nil {
+		t.Fatalf("mkdir bin: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(nestedRoot, "etc", "fstab"), []byte(""), 0o644); err != nil {
+		t.Fatalf("write fstab: %v", err)
+	}
+
+	detector := filesystem.NewDetector(nil)
+	mounts, err := detector.Detect(context.Background(), root)
+	if err != nil {
+		t.Fatalf("detect: %v", err)
+	}
+
+	var found bool
+	for _, mnt := range mounts {
+		if strings.HasSuffix(mnt.ImagePath, "rootfs") && mnt.Type == "directory" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected nested root directory mount in %#v", mounts)
+	}
+}
+
+func TestFilesystemDetectorDetectsMTDStrings(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	img := filepath.Join(root, "flash.bin")
+	data := []byte("bootloader\nmtdparts=flash:512k@0(boot);1536k@0x80000(rootfs)")
+	if err := os.WriteFile(img, data, 0o644); err != nil {
+		t.Fatalf("write flash: %v", err)
+	}
+
+	detector := filesystem.NewDetector(nil)
+	mounts, err := detector.Detect(context.Background(), root)
+	if err != nil {
+		t.Fatalf("detect: %v", err)
+	}
+
+	var found bool
+	for _, mnt := range mounts {
+		if mnt.Type == "mtd" && strings.HasSuffix(mnt.ImagePath, "flash.bin") {
+			if !strings.Contains(mnt.Notes, "mtdparts") {
+				t.Fatalf("expected mtd notes, got %s", mnt.Notes)
+			}
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected mtd detection in %#v", mounts)
+	}
+}

--- a/tests/report_test.go
+++ b/tests/report_test.go
@@ -1,0 +1,93 @@
+package tests
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"firmwareanalyzer/pkg/binaryinspector"
+	"firmwareanalyzer/pkg/extractor"
+	"firmwareanalyzer/pkg/filesystem"
+	"firmwareanalyzer/pkg/report"
+)
+
+func TestReportMarkdownContainsSections(t *testing.T) {
+	summary := report.Summary{
+		Firmware: "sample.bin",
+		Extraction: &extractor.Result{
+			OutputDir: "/tmp/out",
+			Partitions: []extractor.Partition{{
+				Name:   "rootfs.squashfs",
+				Path:   "/tmp/out/rootfs.squashfs",
+				Type:   "squashfs",
+				Size:   1024,
+				Offset: 4096,
+				Notes:  "detected via extension",
+			}},
+		},
+		FileSystems: []filesystem.Mount{{
+			ImagePath: "/tmp/out/rootfs.squashfs",
+			Type:      "squashfs",
+			Size:      1024,
+			Offset:    0,
+			Notes:     "magic matched",
+		}},
+		Binaries: []binaryinspector.Result{{Path: "/bin/app"}},
+	}
+
+	gen := report.NewGenerator(nil)
+	md := gen.Markdown(summary)
+	if md == "" {
+		t.Fatalf("expected markdown output")
+	}
+	if !strings.Contains(md, "# Drone Firmware Analyzer Report") {
+		t.Fatalf("missing heading: %s", md)
+	}
+	if !strings.Contains(md, "Offset") {
+		t.Fatalf("expected offset column: %s", md)
+	}
+}
+
+func TestReportWriteFilesHonoursFormats(t *testing.T) {
+	t.Parallel()
+
+	summary := report.Summary{
+		Firmware: "sample.bin",
+		Extraction: &extractor.Result{
+			OutputDir: "/tmp/out",
+		},
+	}
+	gen := report.NewGenerator(nil)
+	outDir := t.TempDir()
+	paths, err := gen.WriteFiles(summary, outDir, report.Formats{Markdown: true, JSON: true})
+	if err != nil {
+		t.Fatalf("write files: %v", err)
+	}
+	if paths.HTML != "" {
+		t.Fatalf("expected html path to be empty when not requested, got %s", paths.HTML)
+	}
+	if _, err := os.Stat(paths.Markdown); err != nil {
+		t.Fatalf("missing markdown file: %v", err)
+	}
+	if _, err := os.Stat(paths.JSON); err != nil {
+		t.Fatalf("missing json file: %v", err)
+	}
+	data, err := os.ReadFile(paths.JSON)
+	if err != nil {
+		t.Fatalf("read json: %v", err)
+	}
+	if !strings.Contains(string(data), "sample.bin") {
+		t.Fatalf("expected firmware name in json, got %s", string(data))
+	}
+	mdData, err := os.ReadFile(paths.Markdown)
+	if err != nil {
+		t.Fatalf("read markdown: %v", err)
+	}
+	if !strings.Contains(string(mdData), "Drone Firmware Analyzer Report") {
+		t.Fatalf("markdown missing heading")
+	}
+	if filepath.Dir(paths.Markdown) != outDir {
+		t.Fatalf("markdown path outside output dir")
+	}
+}

--- a/tests/secrets_test.go
+++ b/tests/secrets_test.go
@@ -1,0 +1,88 @@
+package tests
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"firmwareanalyzer/pkg/secrets"
+)
+
+func TestSecretsScannerFindsPasswords(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	file := filepath.Join(root, "credentials.txt")
+	if err := os.WriteFile(file, []byte("username=admin\npassword=SuperSecret123\n"), 0o644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	scanner := secrets.NewScanner(nil, nil)
+	findings, err := scanner.Scan(context.Background(), root)
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+
+	if len(findings) == 0 {
+		t.Fatalf("expected secret finding, got %#v", findings)
+	}
+
+	var hasPassword bool
+	for _, finding := range findings {
+		if finding.Rule == "Password Assignment" {
+			hasPassword = true
+		}
+	}
+	if !hasPassword {
+		t.Fatalf("expected password assignment rule, got %#v", findings)
+	}
+}
+
+func TestSecretsScannerDetectsJWTAndAllowsSuppression(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	file := filepath.Join(root, "tokens.txt")
+	jwt := "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkRyb25lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
+	slack := "xoxb-1234567890-token"
+	content := "JWT=" + jwt + "\nSLACK=" + slack + "\n"
+	if err := os.WriteFile(file, []byte(content), 0o644); err != nil {
+		t.Fatalf("write token file: %v", err)
+	}
+
+	scanner := secrets.NewScanner(nil, nil)
+	findings, err := scanner.Scan(context.Background(), root)
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+
+	var hasJWT, hasSlack bool
+	for _, finding := range findings {
+		if finding.Rule == "JWT" {
+			hasJWT = true
+		}
+		if finding.Rule == "Slack Token" {
+			hasSlack = true
+		}
+	}
+	if !hasJWT || !hasSlack {
+		t.Fatalf("expected jwt and slack detections, got %#v", findings)
+	}
+
+	opts := secrets.ScannerOptions{
+		AllowRulePatterns: map[string][]string{
+			"Slack Token": {"xoxb-*"},
+		},
+	}
+	scanner = secrets.NewScannerWithOptions(nil, opts)
+	findings, err = scanner.Scan(context.Background(), root)
+	if err != nil {
+		t.Fatalf("scan with suppression: %v", err)
+	}
+	for _, finding := range findings {
+		if finding.Rule == "Slack Token" {
+			t.Fatalf("expected slack token to be suppressed, got %#v", findings)
+		}
+	}
+}

--- a/tests/service_test.go
+++ b/tests/service_test.go
@@ -1,0 +1,34 @@
+package tests
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"firmwareanalyzer/pkg/service"
+)
+
+func TestServiceDetectorFindsInitScripts(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	initDir := filepath.Join(root, "etc", "init.d")
+	if err := os.MkdirAll(initDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	script := filepath.Join(initDir, "S10daemon")
+	if err := os.WriteFile(script, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("write script: %v", err)
+	}
+
+	detector := service.NewDetector(nil)
+	services, err := detector.Detect(context.Background(), root)
+	if err != nil {
+		t.Fatalf("detect: %v", err)
+	}
+
+	if len(services) == 0 {
+		t.Fatalf("expected services, got %#v", services)
+	}
+}

--- a/tests/utils_test.go
+++ b/tests/utils_test.go
@@ -1,0 +1,55 @@
+package tests
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"firmwareanalyzer/pkg/utils"
+)
+
+func TestFlattenProducesDotNotation(t *testing.T) {
+	input := map[string]any{
+		"db": map[string]any{
+			"host": "localhost",
+			"creds": map[string]any{
+				"user": "root",
+				"pass": "secret",
+			},
+		},
+	}
+	flat := utils.Flatten("", input)
+	if flat["db.host"] != "localhost" {
+		t.Fatalf("unexpected host: %v", flat["db.host"])
+	}
+	if _, ok := flat["db.creds.pass"]; !ok {
+		t.Fatalf("expected credential path in flattened map")
+	}
+}
+
+func TestShannonEntropyRanges(t *testing.T) {
+	if utils.ShannonEntropy("aaaaa") >= utils.ShannonEntropy("abc123XYZ") {
+		t.Fatalf("expected higher entropy for mixed string")
+	}
+}
+
+func TestLooksLikeRoot(t *testing.T) {
+	dir := t.TempDir()
+	must := func(err error) {
+		if err != nil {
+			t.Fatalf("setup: %v", err)
+		}
+	}
+	must(os.Mkdir(filepath.Join(dir, "etc"), 0o755))
+	must(os.Mkdir(filepath.Join(dir, "bin"), 0o755))
+	must(os.WriteFile(filepath.Join(dir, "etc", "fstab"), []byte(""), 0o644))
+
+	if !utils.LooksLikeRoot(dir) {
+		t.Fatalf("expected directory to look like root")
+	}
+
+	other := t.TempDir()
+	if utils.LooksLikeRoot(other) {
+		t.Fatalf("unexpected root detection for empty dir")
+	}
+}


### PR DESCRIPTION
## Summary
- extend extraction and filesystem discovery to surface nested roots, GPT offsets, and MTD metadata for richer partition reporting
- add YAML parsing, reusable root heuristics, and configurable secret scanning with expanded firmware-friendly pattern coverage
- emit JSON reports alongside Markdown/HTML with CLI format controls and broadened test coverage across new behaviors

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d599361b8483269e40391fa6b7fd85