### PR TITLE
Improve snapshot exports and online CVE fallbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,225 @@
-# Firmware_Analyzer
-Firmware Analyzer
+# Drone Firmware Analyzer
+
+Drone Firmware Analyzer is a modular Go toolkit for extracting and auditing
+firmware images from small IoT and drone platforms. It emphasises quick
+analysis workflows by combining light-weight extraction, configuration parsing,
+service discovery, secrets scanning, and ELF hardening inspection into a single
+CLI entrypoint.
+
+## Features
+
+- Firmware extraction with built-in support for tar/tgz/zip images, nested
+  partition discovery, and workspace normalisation
+- Filesystem probing for SquashFS, UBI, ext, GPT and MTD images without mounts
+- Configuration parsing across JSON, XML, YAML, TOML and INI with credential
+  heuristics
+- Service detection for SysV/BUSYBOX init scripts and systemd units
+- Regex and entropy based secrets scanning with allow-list support
+- Binary hardening analysis with Markdown, HTML and JSON reporting
+- CVE enrichment for inspected binaries using offline hash databases
+- SBOM generation (SPDX JSON, SPDX tag-value, or CycloneDX) with optional
+  Ed25519 signing for downstream tooling
+- Plugin execution framework for custom checks written in any language
+- Optional online CVE enrichment via OSV/NVD with caching and rate limiting
+- Firmware-to-firmware diff reports in Markdown and JSON for regression triage
+- Web dashboard for browsing stored analyses and on-demand diff comparisons
+- Batch scheduler capable of dispatching analyses locally or over SSH
+
+## Prerequisites
+
+- **Go 1.22 or later** – required to build the analyzer (`go env GOVERSION`).
+- **Git** – to clone this repository.
+- **Optional extractors** – `unblob` and `binwalk` are used when available to
+  handle complex firmware containers:
+
+  ```bash
+  # Ubuntu / Debian
+  sudo apt-get update && sudo apt-get install binwalk
+
+  # macOS (Homebrew)
+  brew install binwalk
+
+  # Install unblob via pipx
+  pipx install unblob
+  ```
+
+- **Common archive utilities** – ensure `tar`, `gzip`, and `zip` are present on
+  the system (installed by default on most Linux/macOS distributions).
+
+## Installation
+
+Clone the repository and build the analyzer binary:
+
+```bash
+git clone https://github.com/Sandesh028/Firmware_Analyzer.git
+cd Firmware_Analyzer
+go build ./cmd/analyzer
+```
+
+To install the analyzer into your `$GOBIN` for repeated use (including the
+dashboard, scheduler, and vulnerability feed helper), run:
+
+```bash
+go install ./cmd/analyzer ./cmd/dashboard ./cmd/scheduler ./cmd/vulndbupdate
+```
+
+Run the test suite to verify your environment:
+
+```bash
+go test ./...
+```
+
+## Usage
+
+```bash
+go run ./cmd/analyzer --fw /path/to/firmware.bin --out /tmp/report \
+  --report-formats markdown,json \
+  --vuln-db /path/to/vuln-db.json \
+  --sbom-format spdx-json,spdx-tag-value \
+  --sbom-sign-key ./keys/ed25519.pem \
+  --enable-osv --enable-nvd --vuln-cache-dir /tmp/cache \
+  --plugin-dir ./plugins
+```
+
+The analyzer writes the extracted workspace and generated artefacts inside the
+specified output directory. When `--out` is omitted a temporary workspace is
+created alongside the extracted firmware.
+
+### Command reference
+
+- `--fw` – path to the firmware image (required).
+- `--out` – directory where extraction and reports are written. If omitted a
+  temporary directory is used.
+- `--report-formats` – comma separated list selecting `markdown`, `html`, and/or
+  `json` outputs.
+- `--vuln-db` – comma separated list of offline CVE database files. Each file
+  should map SHA-256 hashes to CVE arrays. When omitted the analyzer falls back
+  to the curated database bundled at build time.
+- `--sbom-format` – comma separated SBOM formats (`spdx-json`, `spdx-tag-value`,
+  `cyclonedx`, or `none`).
+- `--sbom-sign-key` – path to an Ed25519 private key in PEM format used to sign
+  generated SBOM artefacts (produces `.sig` files alongside each SBOM).
+- `--baseline-report` – path to a previous `report.json` used for diffing the
+  current analysis against a baseline.
+- `--diff-formats` – comma separated diff artefact formats (`markdown`, `json`).
+- `--history-dir` – directory where run metadata is stored for the dashboard.
+- `--plugin-dir` – directory containing executable plugins. Plugins receive the
+  analysis metadata as JSON on stdin together with `ANALYZER_ROOT` and
+  `ANALYZER_METADATA_FORMAT=json` environment variables.
+- `--enable-osv` / `--osv-endpoint` – enable and optionally override the OSV
+  API endpoint for online CVE enrichment.
+- `--enable-nvd` / `--nvd-endpoint` / `--nvd-api-key` – enable NVD lookups,
+  override the endpoint, and provide an API key when required by rate limits.
+- `--vuln-cache-dir` – directory where online lookup responses are cached to
+  avoid duplicate API calls across runs.
+- `--vuln-rate-limit` – maximum number of online vulnerability requests per
+  minute (defaults to 30 when unset).
+
+### Explore the tool
+
+- Generate all report formats plus signed SPDX JSON + tag-value SBOMs:
+
+  ```bash
+  ./analyzer --fw firmware.bin --out ./analysis \
+    --report-formats markdown,html,json \
+    --sbom-format spdx-json,spdx-tag-value \
+    --sbom-sign-key ./keys/ed25519.pem
+  ```
+
+- Run with an offline vulnerability feed and a custom plugin suite:
+
+  ```bash
+  ./analyzer --fw firmware.bin --out ./analysis --vuln-db ./feeds/openwrt.json --plugin-dir ./plugins
+  ```
+
+- Compare a new firmware against a previous report and enable online CVE
+  lookups with caching:
+
+  ```bash
+  ./analyzer --fw firmware-new.bin --out ./analysis \
+    --baseline-report ./previous/report.json --diff-formats markdown,json \
+    --enable-osv --enable-nvd --vuln-cache-dir ~/.cache/analyzer-cves
+  ```
+
+- Quickly triage a sample firmware using the Go toolchain without installing a
+  binary:
+
+  ```bash
+  go run ./cmd/analyzer --fw tests/fixtures/sample.bin --report-formats markdown
+  ```
+
+### Dashboard server
+
+- Persist history alongside reports by setting `--history-dir` (defaults to
+  `<out>/history` when `--out` is provided):
+
+  ```bash
+  ./analyzer --fw firmware.bin --out ./analysis --history-dir ./analysis/history
+  ```
+
+- Launch the dashboard to browse stored runs and request diffs on demand:
+
+  ```bash
+  ./dashboard --history-dir ./analysis/history --listen :8080
+  ```
+
+  Open `http://localhost:8080` in a browser to inspect the table of analyses,
+  drill into summaries, and diff any two runs.
+
+### Batch scheduler
+
+- Prepare a JSON plan with one or more jobs:
+
+  ```json
+  {
+    "jobs": [
+      {
+        "id": "release-rc1",
+        "firmware": "images/fw-rc1.bin",
+        "output_dir": "runs/rc1",
+        "history_dir": "history",
+        "report_formats": ["markdown", "json"]
+      },
+      {
+        "id": "release-rc2",
+        "firmware": "images/fw-rc2.bin",
+        "output_dir": "runs/rc2",
+        "remote_host": "edge-lab",
+        "extra_args": ["--enable-osv"]
+      }
+    ]
+  }
+  ```
+
+- Define optional remote hosts (SSH targets must have access to the firmware
+  path and analyzer binary):
+
+  ```bash
+  ./scheduler --plan jobs.json \
+    --history-dir history \
+    --remote-host edge-lab=user@edge-host,analyzer=/usr/local/bin/analyzer
+  ```
+
+  Scheduler progress is streamed to stdout, and results populate the shared
+  history directory for the dashboard.
+
+### Curated vulnerability database
+
+- A maintained baseline is shipped in `pkg/vuln/data/curated.json` and embedded into
+  the analyzer binary so vulnerability lookups work out of the box.
+- Refresh the curated feed at release time by merging upstream sources with the
+  helper CLI:
+
+  ```bash
+  go run ./cmd/vulndbupdate --source feeds/openwrt.json --source feeds/vendor.json --out pkg/vuln/data/curated.json
+  ```
+
+- To fetch feeds over plain HTTP, add `--insecure-http` explicitly.
+
+## Development
+
+Run the full test suite before submitting changes:
+
+```bash
+go test ./...
+```

--- a/cmd/analyzer/main.go
+++ b/cmd/analyzer/main.go
@@ -1,0 +1,580 @@
+package main
+
+import (
+	"context"
+	"encoding/base64"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"firmwareanalyzer/pkg/binaryinspector"
+	"firmwareanalyzer/pkg/configparser"
+	"firmwareanalyzer/pkg/dashboard"
+	"firmwareanalyzer/pkg/diff"
+	"firmwareanalyzer/pkg/extractor"
+	"firmwareanalyzer/pkg/filesystem"
+	"firmwareanalyzer/pkg/plugin"
+	"firmwareanalyzer/pkg/report"
+	"firmwareanalyzer/pkg/sbom"
+	"firmwareanalyzer/pkg/secrets"
+	"firmwareanalyzer/pkg/service"
+	"firmwareanalyzer/pkg/vuln"
+)
+
+func main() {
+	firmwarePath := flag.String("fw", "", "path to the firmware image")
+	outputDir := flag.String("out", "", "directory for reports and working files")
+	formatFlag := flag.String("report-formats", "markdown,html,json", "comma-separated list of report formats (markdown, html, json)")
+	vulnDBFlag := flag.String("vuln-db", "", "comma-separated list of CVE database files")
+	sbomFormatFlag := flag.String("sbom-format", "spdx-json", "SBOM output formats (comma-separated: spdx-json, spdx-tag-value, cyclonedx, none)")
+	sbomSignKey := flag.String("sbom-sign-key", "", "path to an Ed25519 private key for signing SBOM artefacts")
+	pluginDirFlag := flag.String("plugin-dir", "", "directory containing analyzer plugins")
+	baselineReport := flag.String("baseline-report", "", "path to a baseline JSON report for diff generation")
+	diffFormatsFlag := flag.String("diff-formats", "markdown,json", "comma-separated diff report formats (markdown, json)")
+	historyDirFlag := flag.String("history-dir", "", "directory for storing analysis history for the dashboard")
+	enableOSV := flag.Bool("enable-osv", false, "query the OSV API for additional CVE data")
+	osvEndpoint := flag.String("osv-endpoint", "https://api.osv.dev/v1/query", "override OSV API endpoint")
+	enableNVD := flag.Bool("enable-nvd", false, "query the NVD API for additional CVE data")
+	nvdEndpoint := flag.String("nvd-endpoint", "https://services.nvd.nist.gov/rest/json/cves/2.0", "override NVD API endpoint")
+	nvdAPIKey := flag.String("nvd-api-key", "", "NVD API key used when performing online lookups")
+	vulnCacheDir := flag.String("vuln-cache-dir", "", "directory for caching online CVE responses")
+	vulnRateLimit := flag.Int("vuln-rate-limit", 30, "maximum online CVE requests per minute")
+	flag.Parse()
+
+	if *firmwarePath == "" {
+		log.Fatal("missing required --fw flag")
+	}
+
+	ctx := context.Background()
+	logger := log.New(os.Stdout, "analyzer ", log.LstdFlags)
+	start := time.Now()
+
+	workDir := ""
+	if *outputDir != "" {
+		workDir = filepath.Join(*outputDir, "workspace")
+	}
+
+	ext := extractor.New(extractor.Options{WorkDir: workDir, PreserveTemp: true}, logger)
+	extraction, err := ext.Extract(ctx, *firmwarePath)
+	if err != nil {
+		log.Fatalf("extraction failed: %v", err)
+	}
+
+	analysisRoot := extraction.OutputDir
+
+	fsDetector := filesystem.NewDetector(logger)
+	mounts, err := fsDetector.Detect(ctx, analysisRoot)
+	if err != nil {
+		logger.Printf("filesystem detection error: %v", err)
+	}
+
+	cfgParser := configparser.NewParser(logger)
+	configs, err := cfgParser.Parse(ctx, analysisRoot)
+	if err != nil {
+		logger.Printf("config parsing error: %v", err)
+	}
+
+	svcDetector := service.NewDetector(logger)
+	services, err := svcDetector.Detect(ctx, analysisRoot)
+	if err != nil {
+		logger.Printf("service detection error: %v", err)
+	}
+
+	secretScanner := secrets.NewScanner(logger, nil)
+	secretFindings, err := secretScanner.Scan(ctx, analysisRoot)
+	if err != nil {
+		logger.Printf("secret scanning error: %v", err)
+	}
+
+	inspector := binaryinspector.NewInspector(logger)
+	binaries, err := inspector.Inspect(ctx, analysisRoot)
+	if err != nil {
+		logger.Printf("binary inspection error: %v", err)
+	}
+
+	vulnOpts := vuln.Options{
+		DatabasePaths:      parseList(*vulnDBFlag),
+		CacheDir:           *vulnCacheDir,
+		RateLimitPerMinute: *vulnRateLimit,
+	}
+	if *enableOSV {
+		vulnOpts.OSV.Enabled = true
+		vulnOpts.OSV.Endpoint = *osvEndpoint
+	}
+	if *enableNVD {
+		vulnOpts.NVD.Enabled = true
+		vulnOpts.NVD.Endpoint = *nvdEndpoint
+		vulnOpts.NVD.APIKey = *nvdAPIKey
+	}
+	vulnEnricher := vuln.NewEnricher(logger, vulnOpts)
+	vulnerabilityFindings, err := vulnEnricher.Enrich(ctx, binaries)
+	if err != nil {
+		logger.Printf("vulnerability enrichment error: %v", err)
+	}
+
+	sbomFormats, err := parseSBOMFormats(*sbomFormatFlag)
+	if err != nil {
+		log.Fatalf("invalid sbom format: %v", err)
+	}
+	var sbomGenerator *sbom.Generator
+	if len(sbomFormats) > 0 {
+		sbomGenerator, err = sbom.NewGenerator(logger, sbom.Options{
+			Formats:        sbomFormats,
+			ProductName:    filepath.Base(*firmwarePath),
+			SigningKeyPath: *sbomSignKey,
+		})
+		if err != nil {
+			log.Fatalf("sbom signer: %v", err)
+		}
+	}
+
+	pluginRunner := plugin.NewRunner(logger, plugin.Options{Directory: *pluginDirFlag})
+	pluginResults, err := pluginRunner.Run(ctx, plugin.Metadata{
+		Firmware:        *firmwarePath,
+		Root:            analysisRoot,
+		Partitions:      extraction.Partitions,
+		FileSystems:     mounts,
+		Configs:         configs,
+		Services:        services,
+		Secrets:         secretFindings,
+		Binaries:        binaries,
+		Vulnerabilities: vulnerabilityFindings,
+	})
+	if err != nil {
+		logger.Printf("plugin execution error: %v", err)
+	}
+
+	summary := report.Summary{
+		Firmware:    *firmwarePath,
+		Extraction:  extraction,
+		FileSystems: mounts,
+		Configs:     configs,
+		Services:    services,
+		Secrets:     secretFindings,
+		Binaries:    binaries,
+		Vulnerable:  vulnerabilityFindings,
+		Plugins:     pluginResults,
+	}
+
+	formats, err := parseReportFormats(*formatFlag)
+	if err != nil {
+		log.Fatalf("invalid report format: %v", err)
+	}
+
+	generator := report.NewGenerator(logger)
+	outDir := *outputDir
+	if outDir == "" {
+		outDir = filepath.Join(extraction.OutputDir, "report")
+	}
+
+	if sbomGenerator != nil {
+		if err := os.MkdirAll(outDir, 0o755); err != nil {
+			logger.Printf("sbom output directory error: %v", err)
+		} else {
+			doc, err := sbomGenerator.Generate(ctx, analysisRoot, binaries, extraction.Partitions)
+			if err != nil {
+				logger.Printf("sbom generation error: %v", err)
+			} else {
+				for _, format := range sbomGenerator.Formats() {
+					data, ext, err := sbom.Encode(doc, format)
+					if err != nil {
+						logger.Printf("sbom encode (%s) error: %v", format, err)
+						continue
+					}
+					sbomPath := filepath.Join(outDir, fmt.Sprintf("sbom.%s", ext))
+					if err := os.WriteFile(sbomPath, data, 0o644); err != nil {
+						logger.Printf("sbom write error: %v", err)
+						continue
+					}
+					summary.SBOM = &doc
+					summary.SBOMPaths = append(summary.SBOMPaths, sbomPath)
+					if summary.SBOMPath == "" {
+						summary.SBOMPath = sbomPath
+					}
+					sig, err := sbomGenerator.Sign(data)
+					if err != nil {
+						logger.Printf("sbom signing error: %v", err)
+						continue
+					}
+					if len(sig) > 0 {
+						sigPath := sbomPath + ".sig"
+						encoded := base64.StdEncoding.EncodeToString(sig)
+						if err := os.WriteFile(sigPath, []byte(encoded), 0o600); err != nil {
+							logger.Printf("sbom signature write error: %v", err)
+						} else {
+							summary.SBOMSignatures = append(summary.SBOMSignatures, sigPath)
+						}
+					}
+				}
+			}
+		}
+	}
+
+	paths, err := generator.WriteFiles(summary, outDir, formats)
+	if err != nil {
+		log.Fatalf("write report: %v", err)
+	}
+
+	logger.Printf("reports written (md=%s html=%s json=%s)", paths.Markdown, paths.HTML, paths.JSON)
+	if len(summary.SBOMPaths) > 0 {
+		for _, p := range summary.SBOMPaths {
+			logger.Printf("sbom written %s", p)
+		}
+	}
+	if len(summary.SBOMSignatures) > 0 {
+		for _, p := range summary.SBOMSignatures {
+			logger.Printf("sbom signature %s", p)
+		}
+	}
+
+	var diffPaths *diff.Paths
+	if *baselineReport != "" {
+		baseline, err := report.LoadJSON(*baselineReport)
+		if err != nil {
+			log.Fatalf("load baseline report: %v", err)
+		}
+		diffFormats, err := parseDiffFormats(*diffFormatsFlag)
+		if err != nil {
+			log.Fatalf("invalid diff format: %v", err)
+		}
+		diffResult := diff.Compute(summary, baseline)
+		dp, err := diff.WriteFiles(diffResult, outDir, diffFormats)
+		if err != nil {
+			log.Fatalf("write diff report: %v", err)
+		}
+		diffPaths = &dp
+		logger.Printf("diff report written (md=%s json=%s)", dp.Markdown, dp.JSON)
+	}
+
+	duration := time.Since(start)
+
+	historyDir := strings.TrimSpace(*historyDirFlag)
+	if historyDir == "" && outDir != "" {
+		historyDir = filepath.Join(outDir, "history")
+	}
+	if historyDir != "" {
+		store, err := dashboard.NewFileStore(historyDir, logger)
+		if err != nil {
+			logger.Printf("history store error: %v", err)
+		} else {
+			if _, err := store.Record(ctx, summary, paths, diffPaths, duration); err != nil {
+				logger.Printf("history record error: %v", err)
+			}
+		}
+	}
+
+	if err := snapshotRun(logger, *firmwarePath, outDir, paths, summary.SBOMPaths, summary.SBOMSignatures, diffPaths); err != nil {
+		logger.Printf("snapshot error: %v", err)
+	}
+
+	logger.Printf("analysis complete in %s", duration.Round(time.Millisecond))
+}
+
+func parseReportFormats(value string) (report.Formats, error) {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return report.DefaultFormats, nil
+	}
+	var formats report.Formats
+	tokens := strings.Split(trimmed, ",")
+	for _, token := range tokens {
+		t := strings.TrimSpace(strings.ToLower(token))
+		if t == "" {
+			continue
+		}
+		switch t {
+		case "md", "markdown":
+			formats.Markdown = true
+		case "html":
+			formats.HTML = true
+		case "json":
+			formats.JSON = true
+		default:
+			return report.Formats{}, fmt.Errorf("unknown report format %q", token)
+		}
+	}
+	if !formats.Markdown && !formats.HTML && !formats.JSON {
+		return report.Formats{}, fmt.Errorf("no valid report formats selected")
+	}
+	return formats, nil
+}
+
+func parseList(value string) []string {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return nil
+	}
+	tokens := strings.Split(trimmed, ",")
+	var out []string
+	for _, token := range tokens {
+		t := strings.TrimSpace(token)
+		if t == "" {
+			continue
+		}
+		out = append(out, t)
+	}
+	return out
+}
+
+func parseSBOMFormats(value string) ([]sbom.Format, error) {
+	trimmed := strings.TrimSpace(strings.ToLower(value))
+	if trimmed == "" {
+		return []sbom.Format{sbom.FormatSPDXJSON}, nil
+	}
+	if trimmed == "none" {
+		return nil, nil
+	}
+	tokens := strings.Split(trimmed, ",")
+	var formats []sbom.Format
+	for _, token := range tokens {
+		t := strings.TrimSpace(token)
+		switch t {
+		case "spdx", "spdx-json":
+			formats = append(formats, sbom.FormatSPDXJSON)
+		case "spdx-tag-value", "spdx-tv", "tag-value":
+			formats = append(formats, sbom.FormatSPDXTagValue)
+		case "cyclonedx", "cdx":
+			formats = append(formats, sbom.FormatCycloneDX)
+		case "":
+			continue
+		default:
+			return nil, fmt.Errorf("unknown sbom format %q", token)
+		}
+	}
+	if len(formats) == 0 {
+		return nil, fmt.Errorf("no SBOM formats selected")
+	}
+	return formats, nil
+}
+
+func parseDiffFormats(value string) (diff.Formats, error) {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return diff.DefaultFormats, nil
+	}
+	var formats diff.Formats
+	tokens := strings.Split(trimmed, ",")
+	for _, token := range tokens {
+		t := strings.TrimSpace(strings.ToLower(token))
+		switch t {
+		case "markdown", "md":
+			formats.Markdown = true
+		case "json":
+			formats.JSON = true
+		case "":
+			continue
+		default:
+			return diff.Formats{}, fmt.Errorf("unknown diff format %q", token)
+		}
+	}
+	if !formats.Markdown && !formats.JSON {
+		return diff.Formats{}, fmt.Errorf("no diff formats selected")
+	}
+	return formats, nil
+}
+
+func snapshotRun(logger *log.Logger, firmwarePath, reportDir string, reportPaths report.Paths, sbomPaths, sbomSignatures []string, diffPaths *diff.Paths) error {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("determine working directory: %w", err)
+	}
+	name := sanitizeName(filepath.Base(firmwarePath))
+	if name == "" {
+		name = "firmware"
+	}
+	target := filepath.Join(cwd, fmt.Sprintf("FA_%s", name))
+	snapshotDir, err := ensureUniqueDir(target)
+	if err != nil {
+		return fmt.Errorf("prepare snapshot directory: %w", err)
+	}
+
+	artefacts := collectArtefacts(reportPaths, sbomPaths, sbomSignatures, diffPaths)
+	for _, path := range artefacts {
+		if err := transferArtefact(path, snapshotDir); err != nil {
+			logger.Printf("snapshot move %s: %v", path, err)
+		}
+	}
+
+	if err := mirrorReportDirectory(reportDir, snapshotDir, artefacts); err != nil {
+		logger.Printf("snapshot mirror %s: %v", reportDir, err)
+	}
+
+	if err := writeSnapshotMetadata(snapshotDir, firmwarePath, reportDir); err != nil {
+		return err
+	}
+	logger.Printf("snapshot written %s", snapshotDir)
+	return nil
+}
+
+func writeSnapshotMetadata(dir, firmwarePath, reportDir string) error {
+	metadata := fmt.Sprintf("Firmware: %s\nReports directory: %s\nSnapshot created: %s\n", firmwarePath, reportDir, time.Now().Format(time.RFC3339))
+	return os.WriteFile(filepath.Join(dir, "README.txt"), []byte(metadata), 0o644)
+}
+
+func ensureUniqueDir(base string) (string, error) {
+	candidate := base
+	if info, err := os.Stat(candidate); err == nil {
+		if !info.IsDir() {
+			return "", fmt.Errorf("path %s exists and is not a directory", candidate)
+		}
+		for idx := 1; ; idx++ {
+			next := fmt.Sprintf("%s_%d", base, idx)
+			if _, err := os.Stat(next); os.IsNotExist(err) {
+				candidate = next
+				break
+			}
+		}
+	} else if !os.IsNotExist(err) {
+		return "", err
+	}
+	if err := os.MkdirAll(candidate, 0o755); err != nil {
+		return "", err
+	}
+	return candidate, nil
+}
+
+func sanitizeName(name string) string {
+	cleaned := strings.TrimSpace(name)
+	if cleaned == "" {
+		return ""
+	}
+	replacer := strings.NewReplacer(" ", "_", "/", "_", "\\", "_")
+	cleaned = replacer.Replace(cleaned)
+	cleaned = strings.ReplaceAll(cleaned, "..", "_")
+	return cleaned
+}
+
+func collectArtefacts(reportPaths report.Paths, sbomPaths, sbomSignatures []string, diffPaths *diff.Paths) []string {
+	var paths []string
+	add := func(p string) {
+		if strings.TrimSpace(p) != "" {
+			paths = append(paths, p)
+		}
+	}
+	add(reportPaths.Markdown)
+	add(reportPaths.HTML)
+	add(reportPaths.JSON)
+	for _, p := range sbomPaths {
+		add(p)
+	}
+	for _, p := range sbomSignatures {
+		add(p)
+	}
+	if diffPaths != nil {
+		add(diffPaths.Markdown)
+		add(diffPaths.JSON)
+	}
+	return dedupeStrings(paths)
+}
+
+func transferArtefact(src, dstDir string) error {
+	if strings.TrimSpace(src) == "" {
+		return nil
+	}
+	if err := os.MkdirAll(dstDir, 0o755); err != nil {
+		return err
+	}
+	dst := filepath.Join(dstDir, filepath.Base(src))
+	if err := os.Rename(src, dst); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		if copyErr := copyFile(src, dst); copyErr != nil {
+			return copyErr
+		}
+		if removeErr := os.Remove(src); removeErr != nil && !os.IsNotExist(removeErr) {
+			return removeErr
+		}
+	}
+	return nil
+}
+
+func mirrorReportDirectory(reportDir, snapshotDir string, artefacts []string) error {
+	reportDir = strings.TrimSpace(reportDir)
+	if reportDir == "" {
+		return nil
+	}
+	info, err := os.Stat(reportDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	if !info.IsDir() {
+		return nil
+	}
+	skip := make(map[string]struct{}, len(artefacts))
+	for _, a := range artefacts {
+		if a == "" {
+			continue
+		}
+		skip[filepath.Clean(a)] = struct{}{}
+	}
+	return filepath.WalkDir(reportDir, func(path string, d os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if path == reportDir {
+			return nil
+		}
+		if _, ok := skip[filepath.Clean(path)]; ok {
+			return nil
+		}
+		rel, err := filepath.Rel(reportDir, path)
+		if err != nil {
+			return err
+		}
+		target := filepath.Join(snapshotDir, rel)
+		if d.IsDir() {
+			return os.MkdirAll(target, 0o755)
+		}
+		if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+			return err
+		}
+		return copyFile(path, target)
+	})
+}
+
+func copyFile(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+
+	info, err := in.Stat()
+	if err != nil {
+		return err
+	}
+
+	out, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, info.Mode())
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+
+	if _, err := io.Copy(out, in); err != nil {
+		return err
+	}
+	return out.Sync()
+}
+
+func dedupeStrings(values []string) []string {
+	seen := make(map[string]struct{}, len(values))
+	var result []string
+	for _, v := range values {
+		if _, ok := seen[v]; ok {
+			continue
+		}
+		seen[v] = struct{}{}
+		result = append(result, v)
+	}
+	return result
+}

--- a/cmd/analyzer/main_test.go
+++ b/cmd/analyzer/main_test.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"io"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"firmwareanalyzer/pkg/diff"
+	"firmwareanalyzer/pkg/report"
+)
+
+func TestSnapshotRunCreatesSnapshotDirectory(t *testing.T) {
+	t.Parallel()
+
+	originalWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chdir(originalWD)
+	})
+
+	tmp := t.TempDir()
+	if err := os.Chdir(tmp); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+
+	reportDir := filepath.Join(tmp, "out")
+	if err := os.MkdirAll(reportDir, 0o755); err != nil {
+		t.Fatalf("mkdir out: %v", err)
+	}
+
+	reportPaths := report.Paths{
+		Markdown: filepath.Join(reportDir, "report.md"),
+		HTML:     filepath.Join(reportDir, "report.html"),
+		JSON:     filepath.Join(reportDir, "report.json"),
+	}
+	for _, p := range []string{reportPaths.Markdown, reportPaths.HTML, reportPaths.JSON} {
+		if err := os.WriteFile(p, []byte("content"), 0o644); err != nil {
+			t.Fatalf("write %s: %v", p, err)
+		}
+	}
+
+	diffPaths := &diff.Paths{
+		Markdown: filepath.Join(reportDir, "diff.md"),
+		JSON:     filepath.Join(reportDir, "diff.json"),
+	}
+	for _, p := range []string{diffPaths.Markdown, diffPaths.JSON} {
+		if err := os.WriteFile(p, []byte("diff"), 0o644); err != nil {
+			t.Fatalf("write diff %s: %v", p, err)
+		}
+	}
+
+	workspace := filepath.Join(reportDir, "workspace")
+	if err := os.MkdirAll(workspace, 0o755); err != nil {
+		t.Fatalf("mkdir workspace: %v", err)
+	}
+	extraFile := filepath.Join(workspace, "data.bin")
+	if err := os.WriteFile(extraFile, []byte("bin"), 0o644); err != nil {
+		t.Fatalf("write extra file: %v", err)
+	}
+
+	logger := log.New(io.Discard, "", 0)
+	if err := snapshotRun(logger, "firmware.bin", reportDir, reportPaths, nil, nil, diffPaths); err != nil {
+		t.Fatalf("snapshot run: %v", err)
+	}
+
+	snapshotDir := filepath.Join(tmp, "FA_firmware.bin")
+	if _, err := os.Stat(snapshotDir); err != nil {
+		t.Fatalf("snapshot directory missing: %v", err)
+	}
+
+	expected := []string{"report.md", "report.html", "report.json", "diff.md", "diff.json", "README.txt", filepath.Join("workspace", "data.bin")}
+	for _, name := range expected {
+		if _, err := os.Stat(filepath.Join(snapshotDir, name)); err != nil {
+			t.Fatalf("expected artefact %s: %v", name, err)
+		}
+	}
+
+	for _, p := range []string{reportPaths.Markdown, reportPaths.HTML, reportPaths.JSON, diffPaths.Markdown, diffPaths.JSON} {
+		if _, err := os.Stat(p); !os.IsNotExist(err) {
+			t.Fatalf("expected %s to be moved from report directory", p)
+		}
+	}
+}
+
+func TestSanitizeNameStripsUnsafeCharacters(t *testing.T) {
+	t.Parallel()
+
+	input := "../weird firmware.bin"
+	got := sanitizeName(input)
+	if got == "" || got == input || got == ".." {
+		t.Fatalf("sanitizeName produced unsafe value: %q", got)
+	}
+	if strings.Contains(got, " ") || strings.Contains(got, "..") || strings.Contains(got, "/") {
+		t.Fatalf("sanitizeName did not remove unsafe characters: %q", got)
+	}
+}

--- a/cmd/dashboard/main.go
+++ b/cmd/dashboard/main.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"log"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"firmwareanalyzer/pkg/dashboard"
+)
+
+func main() {
+	historyDir := flag.String("history-dir", "", "directory containing analyzer history records")
+	listen := flag.String("listen", ":8080", "address for the dashboard web server")
+	flag.Parse()
+
+	if *historyDir == "" {
+		log.Fatal("missing required --history-dir")
+	}
+
+	logger := log.New(os.Stdout, "dashboard ", log.LstdFlags)
+	store, err := dashboard.NewFileStore(*historyDir, logger)
+	if err != nil {
+		log.Fatalf("history store: %v", err)
+	}
+	server := dashboard.NewServer(store, logger)
+
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer cancel()
+
+	if err := server.Run(ctx, *listen); err != nil {
+		log.Fatalf("dashboard server: %v", err)
+	}
+}

--- a/cmd/scheduler/main.go
+++ b/cmd/scheduler/main.go
@@ -1,0 +1,164 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+
+	"firmwareanalyzer/pkg/scheduler"
+)
+
+type plan struct {
+	Jobs []scheduler.Job `json:"jobs"`
+}
+
+func main() {
+	planPath := flag.String("plan", "", "path to a JSON plan describing scheduled jobs")
+	analyzerPath := flag.String("analyzer", "analyzer", "path to the analyzer binary")
+	concurrency := flag.Int("concurrency", 2, "maximum concurrent analyses")
+	defaultHistory := flag.String("history-dir", "", "default history directory for jobs missing one")
+	var remoteHosts remoteHostsFlag
+	flag.Var(&remoteHosts, "remote-host", "remote host definition (name=user@host[,analyzer=/path][,ssh=/path])")
+	flag.Parse()
+
+	if *planPath == "" {
+		log.Fatal("missing required --plan file")
+	}
+
+	jobs, err := loadPlan(*planPath)
+	if err != nil {
+		log.Fatalf("load plan: %v", err)
+	}
+	if len(jobs) == 0 {
+		log.Fatal("plan did not contain any jobs")
+	}
+
+	logger := log.New(os.Stdout, "scheduler ", log.LstdFlags)
+	opts := scheduler.Options{
+		AnalyzerPath: *analyzerPath,
+		Concurrency:  *concurrency,
+		Logger:       logger,
+		RemoteHosts:  remoteHosts.toMap(),
+	}
+	sched := scheduler.New(opts)
+
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer cancel()
+
+	results := sched.Start(ctx)
+	go func() {
+		for res := range results {
+			if res.Error != "" {
+				logger.Printf("job %s (%s) failed: %s", res.JobID, res.Firmware, res.Error)
+			} else {
+				logger.Printf("job %s (%s) complete", res.JobID, res.Firmware)
+			}
+		}
+	}()
+
+	for i := range jobs {
+		if *defaultHistory != "" && jobs[i].HistoryDir == "" {
+			jobs[i].HistoryDir = *defaultHistory
+		}
+		if err := sched.Enqueue(jobs[i]); err != nil {
+			log.Fatalf("enqueue job %d: %v", i, err)
+		}
+	}
+
+	sched.Close()
+	<-ctx.Done()
+}
+
+func loadPlan(path string) ([]scheduler.Job, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	trimmed := strings.TrimSpace(string(data))
+	if trimmed == "" {
+		return nil, errors.New("plan file was empty")
+	}
+	if strings.HasPrefix(trimmed, "[") {
+		var jobs []scheduler.Job
+		if err := json.Unmarshal(data, &jobs); err != nil {
+			return nil, err
+		}
+		return jobs, nil
+	}
+	var p plan
+	if err := json.Unmarshal(data, &p); err != nil {
+		return nil, err
+	}
+	return p.Jobs, nil
+}
+
+type remoteHostsFlag struct {
+	hosts map[string]scheduler.RemoteHost
+}
+
+func (r *remoteHostsFlag) String() string {
+	return ""
+}
+
+func (r *remoteHostsFlag) Set(value string) error {
+	if r.hosts == nil {
+		r.hosts = make(map[string]scheduler.RemoteHost)
+	}
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return errors.New("remote host definition cannot be empty")
+	}
+	parts := strings.Split(value, ",")
+	namePair := strings.SplitN(parts[0], "=", 2)
+	if len(namePair) != 2 {
+		return fmt.Errorf("remote host must be in name=target form: %s", value)
+	}
+	name := strings.TrimSpace(namePair[0])
+	target := strings.TrimSpace(namePair[1])
+	if name == "" || target == "" {
+		return fmt.Errorf("invalid remote host declaration: %s", value)
+	}
+	host := scheduler.RemoteHost{Name: name}
+	if at := strings.Index(target, "@"); at >= 0 {
+		host.User = target[:at]
+		host.Address = target[at+1:]
+	} else {
+		host.Address = target
+	}
+	for _, segment := range parts[1:] {
+		segment = strings.TrimSpace(segment)
+		if segment == "" {
+			continue
+		}
+		kv := strings.SplitN(segment, "=", 2)
+		if len(kv) != 2 {
+			return fmt.Errorf("invalid remote host attribute: %s", segment)
+		}
+		key := strings.TrimSpace(kv[0])
+		val := strings.TrimSpace(kv[1])
+		switch key {
+		case "analyzer":
+			host.AnalyzerPath = val
+		case "ssh":
+			host.SSHBinary = val
+		default:
+			return fmt.Errorf("unknown remote host attribute %s", key)
+		}
+	}
+	r.hosts[name] = host
+	return nil
+}
+
+func (r *remoteHostsFlag) toMap() map[string]scheduler.RemoteHost {
+	if r.hosts == nil {
+		return map[string]scheduler.RemoteHost{}
+	}
+	return r.hosts
+}

--- a/cmd/vulndbupdate/main.go
+++ b/cmd/vulndbupdate/main.go
@@ -1,0 +1,138 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"firmwareanalyzer/pkg/vuln"
+)
+
+type sourceList []string
+
+func (s *sourceList) String() string {
+	return strings.Join(*s, ",")
+}
+
+func (s *sourceList) Set(value string) error {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return errors.New("empty source value")
+	}
+	*s = append(*s, value)
+	return nil
+}
+
+func main() {
+	var sources sourceList
+	flag.Var(&sources, "source", "path or URL for a vulnerability feed (repeatable)")
+	output := flag.String("out", "pkg/vuln/data/curated.json", "path to write the merged database")
+	allowInsecure := flag.Bool("insecure-http", false, "allow plain HTTP downloads for feeds")
+	flag.Parse()
+
+	if len(sources) == 0 {
+		log.Fatal("at least one --source must be provided")
+	}
+
+	var databases []map[string][]vuln.CVE
+	for _, src := range sources {
+		data, err := loadSource(src, *allowInsecure)
+		if err != nil {
+			log.Fatalf("load source %s: %v", src, err)
+		}
+		entries, err := vuln.ParseDatabase(data)
+		if err != nil {
+			log.Fatalf("parse source %s: %v", src, err)
+		}
+		databases = append(databases, entries)
+	}
+
+	merged := vuln.Merge(databases...)
+	if len(merged) == 0 {
+		log.Fatal("merged database is empty")
+	}
+
+	if err := writeDatabase(*output, sources, merged); err != nil {
+		log.Fatalf("write database: %v", err)
+	}
+	log.Printf("database written to %s (%d artifacts)", *output, len(merged))
+}
+
+func loadSource(source string, allowInsecure bool) ([]byte, error) {
+	if strings.HasPrefix(source, "http://") || strings.HasPrefix(source, "https://") {
+		if strings.HasPrefix(source, "http://") && !allowInsecure {
+			return nil, fmt.Errorf("insecure http source blocked: %s", source)
+		}
+		req, err := http.NewRequest(http.MethodGet, source, nil)
+		if err != nil {
+			return nil, err
+		}
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			return nil, err
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			return nil, fmt.Errorf("unexpected status %d", resp.StatusCode)
+		}
+		return io.ReadAll(resp.Body)
+	}
+	return os.ReadFile(source)
+}
+
+func writeDatabase(path string, sources []string, db map[string][]vuln.CVE) error {
+	type artifact struct {
+		SHA256 string     `json:"sha256"`
+		CVEs   []vuln.CVE `json:"cves"`
+	}
+	type payload struct {
+		Generated string     `json:"generated"`
+		Sources   []string   `json:"sources"`
+		Artifacts []artifact `json:"artifacts"`
+	}
+
+	hashes := make([]string, 0, len(db))
+	for hash := range db {
+		hashes = append(hashes, hash)
+	}
+	sort.Strings(hashes)
+
+	artifacts := make([]artifact, 0, len(hashes))
+	for _, hash := range hashes {
+		cves := append([]vuln.CVE(nil), db[hash]...)
+		sort.Slice(cves, func(i, j int) bool {
+			return strings.ToLower(cves[i].ID) < strings.ToLower(cves[j].ID)
+		})
+		artifacts = append(artifacts, artifact{SHA256: hash, CVEs: cves})
+	}
+
+	body := payload{
+		Generated: time.Now().UTC().Format(time.RFC3339),
+		Sources:   append([]string(nil), sources...),
+		Artifacts: artifacts,
+	}
+
+	data, err := json.MarshalIndent(body, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+
+	tmpPath := path + ".tmp"
+	if err := os.WriteFile(tmpPath, data, 0o644); err != nil {
+		return err
+	}
+	return os.Rename(tmpPath, path)
+}

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -1,0 +1,59 @@
+# Design Overview
+
+Drone Firmware Analyzer is structured as a collection of focused Go packages
+coordinated by a thin CLI layer. Each package owns a single responsibility and
+exposes testable APIs so that future modules (e.g. SBOM generation or CVE
+matching) can be integrated without modifying the existing workflow heavily.
+
+## Package Responsibilities
+
+- `pkg/extractor` normalises firmware archives into a workspace directory and
+  records partition metadata for downstream modules.
+- `pkg/filesystem` performs signature-based identification of embedded
+  filesystem images without needing privileged mounts.
+- `pkg/configparser` flattens JSON, XML, YAML, TOML and INI configuration files
+  into dot-notated key/value pairs that higher layers can consume.
+- `pkg/service` inventories init scripts and unit files to provide visibility
+  into boot-time services.
+- `pkg/secrets` scans text content for credential material using regular
+  expressions, Shannon entropy and optional allow-lists.
+- `pkg/binaryinspector` analyses ELF binaries for hardening settings such as
+  RELRO, NX and PIE and renders Markdown tables for reports.
+- `pkg/vuln` hashes binaries, enriches them with CVE metadata from offline
+  databases, and can query OSV/NVD feeds with caching and rate limiting.
+- `pkg/sbom` produces SPDX JSON, SPDX tag-value, or CycloneDX documents and can
+  sign artefacts with Ed25519 keys.
+- `pkg/diff` compares a fresh analysis summary against a baseline report and
+  renders Markdown/JSON change logs.
+- `pkg/plugin` executes external scripts that emit JSON findings, enabling
+  custom organisational checks without modifying the core.
+- `pkg/report` composes module results into Markdown, HTML and JSON artefacts.
+- `pkg/dashboard` persists analysis history and serves a lightweight web UI for
+  browsing reports and diffing stored runs.
+- `pkg/scheduler` coordinates batched analyses using worker pools and optional
+  SSH targets while delegating execution to the analyzer CLI.
+- `pkg/utils` hosts shared helpers for map flattening, entropy calculations and
+  heuristic utilities.
+
+## Workflow
+
+1. **Extraction** – The CLI invokes the extractor to unpack the firmware image
+   into a workspace, retaining metadata about detected partitions.
+2. **Scanning** – Filesystem detection, configuration parsing, service
+   discovery, secret scanning and binary inspection operate on the workspace in
+   parallel-friendly fashion (currently sequenced within the CLI for clarity).
+3. **Reporting & history** – The report generator aggregates module outputs into
+   Markdown, HTML and JSON documents, while SBOM artefacts (optionally signed)
+   and vulnerability data are persisted. When `--history-dir` is set the
+   dashboard store snapshots each run so the standalone `cmd/dashboard` server
+   can surface history and diff comparisons.
+4. **Batch execution** – Teams with larger firmware portfolios can describe job
+   plans and optional remote hosts for `cmd/scheduler`, which dispatches the CLI
+   with consistent flags while recording results into the shared history store.
+
+## Testing Strategy
+
+Each package ships with focused unit tests using temporary directories and
+small fixtures to keep the test suite fast and deterministic. The tests validate
+both success paths and heuristic triggers (e.g. credential detection) to guard
+against regressions.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,33 @@
+# Roadmap
+
+The current implementation focuses on core workflows suitable for rapid firmware
+triage. The following milestones track planned enhancements:
+
+## Short Term
+
+- ✅ Ship a curated vulnerability database bundle and tooling to update it
+  alongside releases (`pkg/vuln/data/curated.json` + `cmd/vulndbupdate`).
+- Capture richer filesystem metadata (e.g. partition offsets and compression
+  statistics) for SBOM annotations.
+- Extend plugin execution with structured input (workspace metadata) and
+  enforce resource limits per plugin.
+
+## Medium Term
+
+- ✅ Support additional SBOM formats (e.g. SPDX tag-value) and signing options.
+- ✅ Integrate optional online CVE lookups (OSV, NVD) with caching and rate limiting.
+- ✅ Emit diff reports to compare two firmware images across all analyzers.
+- Automate SBOM publishing pipelines (CycloneDX XML, SPDX Lite) and signature
+  verification tooling.
+- Surface vulnerability severity trends and remediation hints within the CLI
+  output and reports.
+
+## Long Term
+
+- ✅ Offer a web dashboard for browsing analysis history and diffing firmware
+  versions over time.
+- ✅ Introduce a scheduler for batch analysis and remote execution targets.
+- Expose authenticated REST APIs so the dashboard can power multi-user portals
+  and third-party automation.
+- Explore distributed workers that auto-scale via a queue backed by SQS, Redis,
+  or NATS for large firmware corpora.

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -1,0 +1,103 @@
+# Usage Guide
+
+The Drone Firmware Analyzer command line interface orchestrates firmware
+extraction and analysis modules. The minimal invocation requires the firmware
+image path:
+
+```bash
+go run ./cmd/analyzer --fw firmware.tgz --out ./analysis \
+  --report-formats markdown,json \
+  --sbom-format spdx-json,spdx-tag-value --sbom-sign-key ./keys/ed25519.pem \
+  --enable-osv --enable-nvd --vuln-cache-dir ~/.cache/analyzer
+```
+
+## Flags
+
+- `--fw` (required): path to the firmware image archive or directory.
+- `--out`: optional directory where the workspace and generated artefacts will
+  be written. When omitted, a temporary directory under the system temp location
+  is created automatically.
+- `--report-formats`: comma separated list enabling `markdown`, `html`, and/or
+  `json` report outputs. Defaults to all formats.
+- `--vuln-db`: comma separated list of JSON files containing `sha256 -> CVE`
+  mappings used to enrich binary inspection results. When omitted, the embedded
+  `pkg/vuln/data/curated.json` dataset is applied automatically.
+- `--sbom-format`: comma separated SBOM formats (`spdx-json`, `spdx-tag-value`,
+  `cyclonedx`, or `none`).
+- `--sbom-sign-key`: optional Ed25519 private key (PEM) used to sign SBOM
+  artefacts, emitting `.sig` companions.
+- `--baseline-report`: previous `report.json` used for diff generation.
+- `--diff-formats`: comma separated diff outputs (`markdown`, `json`).
+- `--history-dir`: directory where run metadata is written for the dashboard.
+- `--plugin-dir`: directory containing executable scripts that emit JSON
+  findings for custom checks.
+- `--enable-osv` / `--osv-endpoint`: enable OSV lookups and optionally override
+  the API endpoint.
+- `--enable-nvd` / `--nvd-endpoint` / `--nvd-api-key`: enable NVD lookups,
+  change the endpoint, and supply an API key when required.
+- `--vuln-cache-dir`: directory where online CVE responses are cached between
+  runs.
+- `--vuln-rate-limit`: maximum number of online CVE requests per minute.
+
+## Output Structure
+
+```
+<output>/
+├── workspace/       # normalised extraction root
+│   ├── ...
+└── report/
+    ├── report.md        # Markdown summary (if selected)
+    ├── report.html      # HTML view (if selected)
+    ├── report.json      # Structured JSON output (if selected)
+    ├── sbom.spdx.json   # SBOM artefact(s) based on --sbom-format
+    ├── sbom.spdx.sig    # Ed25519 signature(s) when --sbom-sign-key is set
+    └── diff.md/json     # Optional diff reports when --baseline-report is supplied
+└── history/            # Optional dashboard records when --history-dir is set
+```
+
+If `--out` is not provided the report directory is written inside the extracted
+workspace.
+
+## Adding Custom Modules
+
+The analyzer pipeline is intentionally modular. To integrate a new analysis
+stage:
+
+1. Create a package under `pkg/` exposing a Go API that accepts the extraction
+   root path and returns structured findings.
+2. Add unit tests under `tests/` using temporary fixtures to validate behaviour.
+3. Wire the new package into `cmd/analyzer/main.go`, feeding the results into the
+   `report.Summary` structure so they surface in the generated reports.
+
+## Maintaining the curated CVE bundle
+
+Releases embed `pkg/vuln/data/curated.json` into the analyzer binary. Regenerate the
+feed before shipping a release by merging upstream JSON feeds:
+
+```bash
+go run ./cmd/vulndbupdate --source feeds/openwrt.json --source feeds/vendor.json --out pkg/vuln/data/curated.json
+```
+
+The helper only allows HTTPS downloads by default. Use `--insecure-http` if a
+source lacks TLS, and provide additional `--source` flags as required.
+
+## Dashboard and scheduler helpers
+
+- **Dashboard**: enable history recording by setting `--history-dir` when running
+  the analyzer. Afterwards, start the dashboard service to browse prior runs and
+  trigger diff comparisons:
+
+  ```bash
+  ./dashboard --history-dir ./analysis/history --listen :8080
+  ```
+
+- **Scheduler**: batch multiple firmware analyses from a plan file and optional
+  remote hosts:
+
+  ```bash
+  ./scheduler --plan jobs.json --history-dir history --remote-host edge=user@edge-host
+  ```
+
+  Each job in the plan mirrors the analyzer flags (e.g., `report_formats`,
+  `extra_args`, `remote_host`) and results are recorded into the shared history
+  directory for dashboard consumption.

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module firmwareanalyzer
+
+go 1.22
+
+require gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/pkg/binaryinspector/binaryinspector.go
+++ b/pkg/binaryinspector/binaryinspector.go
@@ -1,0 +1,305 @@
+package binaryinspector
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"debug/elf"
+)
+
+// ErrNotELF is returned when the inspected file is not an ELF binary.
+var ErrNotELF = errors.New("not an ELF binary")
+
+// RELROLevel represents the strength of RELRO hardening applied to an ELF binary.
+type RELROLevel string
+
+const (
+	// RELRONone indicates that the binary does not request RELRO protection.
+	RELRONone RELROLevel = "none"
+	// RELROPartial indicates that the binary has PT_GNU_RELRO but performs lazy binding.
+	RELROPartial RELROLevel = "partial"
+	// RELROFull indicates that the binary has PT_GNU_RELRO and enforces immediate binding.
+	RELROFull RELROLevel = "full"
+)
+
+// Result holds hardening attributes detected for a single ELF binary.
+type Result struct {
+	Path         string     `json:"path"`
+	Type         string     `json:"type"`
+	Architecture string     `json:"architecture"`
+	RELRO        RELROLevel `json:"relro"`
+	NXEnabled    bool       `json:"nx_enabled"`
+	PIEEnabled   bool       `json:"pie_enabled"`
+	Stripped     bool       `json:"stripped"`
+	Interpreter  string     `json:"interpreter,omitempty"`
+	Err          string     `json:"error,omitempty"`
+}
+
+// MarkdownRow returns a Markdown formatted table row describing the binary.
+func (r Result) MarkdownRow() string {
+	status := func(b bool) string {
+		if b {
+			return "✅"
+		}
+		return "❌"
+	}
+
+	relro := strings.ToUpper(string(r.RELRO))
+	if relro == "" {
+		relro = "UNKNOWN"
+	}
+
+	stripped := "No"
+	if r.Stripped {
+		stripped = "Yes"
+	}
+
+	interpreter := r.Interpreter
+	if interpreter == "" {
+		interpreter = "-"
+	}
+
+	return fmt.Sprintf("| %s | %s | %s | %s | %s | %s | %s | %s |",
+		r.Path, r.Type, r.Architecture, relro, status(r.NXEnabled), status(r.PIEEnabled), stripped, interpreter)
+}
+
+// Inspector analyses ELF binaries for common hardening flags.
+type Inspector struct {
+	logger *log.Logger
+}
+
+// NewInspector returns a new Inspector. If logger is nil, logging is discarded.
+func NewInspector(logger *log.Logger) *Inspector {
+	if logger == nil {
+		logger = log.New(io.Discard, "binaryinspector", log.LstdFlags)
+	}
+	return &Inspector{logger: logger}
+}
+
+// Inspect walks the given root directory and inspects any ELF binaries found.
+// The context allows the walk to be cancelled early. Any errors encountered
+// during inspection are captured in the Result.Err field so that processing can
+// continue for other binaries.
+func (i *Inspector) Inspect(ctx context.Context, root string) ([]Result, error) {
+	var results []Result
+	walkErr := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		if d.IsDir() {
+			return nil
+		}
+
+		info, statErr := d.Info()
+		if statErr != nil {
+			return statErr
+		}
+
+		if !info.Mode().IsRegular() {
+			return nil
+		}
+
+		res, inspectErr := i.inspectFile(path)
+		switch {
+		case errors.Is(inspectErr, ErrNotELF):
+			return nil
+		case inspectErr != nil:
+			res.Err = inspectErr.Error()
+			results = append(results, res)
+		default:
+			results = append(results, res)
+		}
+		return nil
+	})
+	if walkErr != nil {
+		return nil, walkErr
+	}
+	return results, nil
+}
+
+func (i *Inspector) inspectFile(path string) (Result, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return Result{Path: path}, fmt.Errorf("open file: %w", err)
+	}
+	defer file.Close()
+
+	header := make([]byte, 4)
+	if _, err := io.ReadFull(file, header); err != nil {
+		return Result{Path: path}, fmt.Errorf("read header: %w", err)
+	}
+	if !bytes.Equal(header, []byte(elf.ELFMAG)) {
+		return Result{Path: path}, ErrNotELF
+	}
+
+	if _, err := file.Seek(0, io.SeekStart); err != nil {
+		return Result{Path: path}, fmt.Errorf("seek: %w", err)
+	}
+
+	ef, err := elf.NewFile(file)
+	if err != nil {
+		return Result{Path: path}, fmt.Errorf("parse ELF: %w", err)
+	}
+	defer ef.Close()
+
+	result := Result{Path: path}
+
+	result.Type = ef.FileHeader.Type.String()
+	result.Architecture = ef.FileHeader.Machine.String()
+	result.PIEEnabled = ef.FileHeader.Type == elf.ET_DYN
+	result.NXEnabled = detectNX(ef)
+
+	relro, relroErr := detectRELRO(ef)
+	if relroErr != nil {
+		return result, fmt.Errorf("detect RELRO: %w", relroErr)
+	}
+	result.RELRO = relro
+
+	result.Stripped = isStripped(ef)
+	result.Interpreter = interpreterPath(ef)
+
+	return result, nil
+}
+
+func detectNX(f *elf.File) bool {
+	for _, prog := range f.Progs {
+		if prog.Type == elf.PT_GNU_STACK {
+			return prog.Flags&elf.PF_X == 0
+		}
+	}
+	return false
+}
+
+func detectRELRO(f *elf.File) (RELROLevel, error) {
+	var hasRelro bool
+	for _, prog := range f.Progs {
+		if prog.Type == elf.PT_GNU_RELRO {
+			hasRelro = true
+			break
+		}
+	}
+	if !hasRelro {
+		return RELRONone, nil
+	}
+
+	tags, err := dynamicTags(f)
+	if err != nil {
+		return RELRONone, err
+	}
+
+	if val, ok := tags[elf.DT_BIND_NOW]; ok && val != 0 {
+		return RELROFull, nil
+	}
+	if val, ok := tags[elf.DT_FLAGS]; ok && elf.DynFlag(val)&elf.DF_BIND_NOW != 0 {
+		return RELROFull, nil
+	}
+	if val, ok := tags[elf.DT_FLAGS_1]; ok && elf.DynFlag1(val)&elf.DF_1_NOW != 0 {
+		return RELROFull, nil
+	}
+
+	return RELROPartial, nil
+}
+
+func isStripped(f *elf.File) bool {
+	symtab := f.Section(".symtab")
+	if symtab == nil {
+		return true
+	}
+	return symtab.Size == 0
+}
+
+func interpreterPath(f *elf.File) string {
+	sec := f.Section(".interp")
+	if sec == nil {
+		return ""
+	}
+
+	data, err := sec.Data()
+	if err != nil {
+		return ""
+	}
+
+	return strings.TrimRight(string(data), "\x00")
+}
+
+func dynamicTags(f *elf.File) (map[elf.DynTag]uint64, error) {
+	dynSec := f.Section(".dynamic")
+	if dynSec == nil {
+		return map[elf.DynTag]uint64{}, nil
+	}
+
+	data, err := dynSec.Data()
+	if err != nil {
+		return nil, err
+	}
+
+	tags := make(map[elf.DynTag]uint64)
+	reader := bytes.NewReader(data)
+
+	switch f.Class {
+	case elf.ELFCLASS32:
+		for {
+			var entry elf.Dyn32
+			if err := binary.Read(reader, f.ByteOrder, &entry); err != nil {
+				if errors.Is(err, io.EOF) {
+					break
+				}
+				return nil, err
+			}
+			if elf.DynTag(entry.Tag) == elf.DT_NULL {
+				break
+			}
+			tags[elf.DynTag(entry.Tag)] = uint64(entry.Val)
+		}
+	case elf.ELFCLASS64:
+		for {
+			var entry elf.Dyn64
+			if err := binary.Read(reader, f.ByteOrder, &entry); err != nil {
+				if errors.Is(err, io.EOF) {
+					break
+				}
+				return nil, err
+			}
+			if elf.DynTag(entry.Tag) == elf.DT_NULL {
+				break
+			}
+			tags[elf.DynTag(entry.Tag)] = entry.Val
+		}
+	default:
+		return nil, fmt.Errorf("unsupported ELF class: %s", f.Class)
+	}
+
+	return tags, nil
+}
+
+// CollectMarkdownTable renders results into a Markdown table body.
+func CollectMarkdownTable(results []Result) string {
+	if len(results) == 0 {
+		return ""
+	}
+
+	var builder strings.Builder
+	builder.WriteString("| Path | Type | Arch | RELRO | NX | PIE | Stripped | Interpreter |\n")
+	builder.WriteString("| --- | --- | --- | --- | --- | --- | --- | --- |\n")
+	for _, res := range results {
+		builder.WriteString(res.MarkdownRow())
+		builder.WriteByte('\n')
+	}
+	return builder.String()
+}

--- a/pkg/configparser/configparser.go
+++ b/pkg/configparser/configparser.go
@@ -1,0 +1,279 @@
+package configparser
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"encoding/xml"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"firmwareanalyzer/pkg/utils"
+
+	yaml "gopkg.in/yaml.v3"
+)
+
+// Parameter represents a flattened configuration entry discovered within a
+// parsed configuration file.
+type Parameter struct {
+	Key        string `json:"key"`
+	Value      string `json:"value"`
+	Credential bool   `json:"credential"`
+}
+
+// Finding groups the parameters produced from parsing a single configuration
+// file.
+type Finding struct {
+	File   string      `json:"file"`
+	Format string      `json:"format"`
+	Params []Parameter `json:"parameters"`
+}
+
+// Parser loads configuration files from extracted firmware directories and
+// normalises them into flattened key/value pairs for downstream analysis.
+type Parser struct {
+	maxSize int64
+	logger  *log.Logger
+}
+
+// NewParser instantiates a Parser with sane defaults.
+func NewParser(logger *log.Logger) *Parser {
+	if logger == nil {
+		logger = log.New(io.Discard, "configparser", log.LstdFlags)
+	}
+	return &Parser{maxSize: 2 << 20, logger: logger}
+}
+
+// Parse walks the provided root directory collecting configuration findings
+// for supported formats (JSON, XML, YAML, TOML, and INI).
+func (p *Parser) Parse(ctx context.Context, root string) ([]Finding, error) {
+	var findings []Finding
+	err := filepath.WalkDir(root, func(path string, d os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.IsDir() {
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		format := detectFormat(path)
+		if format == "" {
+			return nil
+		}
+		finding, err := p.parseFile(path, format)
+		if err != nil {
+			return err
+		}
+		if len(finding.Params) > 0 {
+			findings = append(findings, finding)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return findings, nil
+}
+
+func (p *Parser) parseFile(path, format string) (Finding, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return Finding{}, fmt.Errorf("stat config: %w", err)
+	}
+	if info.Size() > p.maxSize {
+		return Finding{}, fmt.Errorf("config file too large: %s", path)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return Finding{}, fmt.Errorf("read config: %w", err)
+	}
+
+	var flat map[string]string
+	switch format {
+	case "json":
+		var v any
+		dec := json.NewDecoder(bytes.NewReader(data))
+		dec.UseNumber()
+		if err := dec.Decode(&v); err != nil {
+			return Finding{}, fmt.Errorf("parse json: %w", err)
+		}
+		flat = utils.Flatten("", v)
+	case "xml":
+		flat, err = parseXML(data)
+		if err != nil {
+			p.logger.Printf("skipping malformed xml %s: %v", path, err)
+			return Finding{File: path, Format: format}, nil
+		}
+	case "yaml":
+		var raw any
+		if err := yaml.Unmarshal(data, &raw); err != nil {
+			return Finding{}, fmt.Errorf("parse yaml: %w", err)
+		}
+		flat = utils.Flatten("", normalizeYAML(raw))
+	case "toml":
+		flat = parseSimpleKV(data)
+	case "ini":
+		flat = parseINI(data)
+	default:
+		return Finding{}, fmt.Errorf("unsupported format %s", format)
+	}
+
+	params := make([]Parameter, 0, len(flat))
+	for k, v := range flat {
+		params = append(params, Parameter{
+			Key:        k,
+			Value:      v,
+			Credential: utils.ContainsCredentialKeyword(k),
+		})
+	}
+	sort.Slice(params, func(i, j int) bool { return params[i].Key < params[j].Key })
+
+	return Finding{File: path, Format: format, Params: params}, nil
+}
+
+func detectFormat(path string) string {
+	switch strings.ToLower(filepath.Ext(path)) {
+	case ".json":
+		return "json"
+	case ".xml":
+		return "xml"
+	case ".yaml", ".yml":
+		return "yaml"
+	case ".toml":
+		return "toml"
+	case ".ini", ".conf":
+		return "ini"
+	default:
+		return ""
+	}
+}
+
+func parseXML(data []byte) (map[string]string, error) {
+	decoder := xml.NewDecoder(bytes.NewReader(data))
+	decoder.CharsetReader = func(encoding string, input io.Reader) (io.Reader, error) {
+		return input, nil
+	}
+
+	flat := make(map[string]string)
+	var stack []string
+	for {
+		token, err := decoder.Token()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("parse xml: %w", err)
+		}
+		switch tok := token.(type) {
+		case xml.StartElement:
+			stack = append(stack, tok.Name.Local)
+			for _, attr := range tok.Attr {
+				key := strings.Join(append(stack, "@"+attr.Name.Local), ".")
+				flat[key] = attr.Value
+			}
+		case xml.EndElement:
+			if len(stack) > 0 {
+				stack = stack[:len(stack)-1]
+			}
+		case xml.CharData:
+			text := strings.TrimSpace(string(tok))
+			if text == "" {
+				continue
+			}
+			key := strings.Join(stack, ".")
+			flat[key] = text
+		}
+	}
+	return flat, nil
+}
+
+func parseSimpleKV(data []byte) map[string]string {
+	flat := make(map[string]string)
+	scanner := bufio.NewScanner(bytes.NewReader(data))
+	var prefix string
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
+			prefix = strings.Trim(line, "[]")
+			continue
+		}
+		parts := strings.SplitN(line, "=", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		key := strings.TrimSpace(parts[0])
+		value := strings.Trim(strings.TrimSpace(parts[1]), "\"'")
+		if prefix != "" {
+			key = prefix + "." + key
+		}
+		flat[key] = value
+	}
+	return flat
+}
+
+func normalizeYAML(v any) any {
+	switch val := v.(type) {
+	case map[string]any:
+		out := make(map[string]any, len(val))
+		for k, sub := range val {
+			out[k] = normalizeYAML(sub)
+		}
+		return out
+	case map[any]any:
+		out := make(map[string]any, len(val))
+		for k, sub := range val {
+			out[fmt.Sprint(k)] = normalizeYAML(sub)
+		}
+		return out
+	case []any:
+		for i, sub := range val {
+			val[i] = normalizeYAML(sub)
+		}
+		return val
+	default:
+		return val
+	}
+}
+
+func parseINI(data []byte) map[string]string {
+	flat := make(map[string]string)
+	scanner := bufio.NewScanner(bytes.NewReader(data))
+	var section string
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") || strings.HasPrefix(line, ";") {
+			continue
+		}
+		if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
+			section = strings.Trim(line, "[]")
+			continue
+		}
+		parts := strings.SplitN(line, "=", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		key := strings.TrimSpace(parts[0])
+		value := strings.Trim(strings.TrimSpace(parts[1]), "\"'")
+		if section != "" {
+			key = section + "." + key
+		}
+		flat[key] = value
+	}
+	return flat
+}

--- a/pkg/dashboard/server.go
+++ b/pkg/dashboard/server.go
@@ -1,0 +1,229 @@
+package dashboard
+
+import (
+	"context"
+	"encoding/json"
+	"html/template"
+	"io"
+	"log"
+	"net/http"
+	"strings"
+	"time"
+
+	"firmwareanalyzer/pkg/report"
+)
+
+// Server exposes a minimal web UI and JSON API for browsing analysis history.
+type Server struct {
+	store  Store
+	logger *log.Logger
+}
+
+// NewServer constructs a dashboard server backed by the provided store.
+func NewServer(store Store, logger *log.Logger) *Server {
+	if logger == nil {
+		logger = log.New(io.Discard, "dashboard-server", log.LstdFlags)
+	}
+	return &Server{store: store, logger: logger}
+}
+
+// Handler returns an http.Handler implementing the dashboard routes.
+func (s *Server) Handler() http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", s.handleIndex)
+	mux.HandleFunc("/api/records", s.handleRecords)
+	mux.HandleFunc("/api/records/", s.handleRecord)
+	mux.HandleFunc("/api/diff", s.handleDiff)
+	return mux
+}
+
+// Run starts the HTTP server and blocks until the context is cancelled.
+func (s *Server) Run(ctx context.Context, addr string) error {
+	srv := &http.Server{
+		Addr:              addr,
+		Handler:           s.Handler(),
+		ReadHeaderTimeout: 10 * time.Second,
+	}
+	errCh := make(chan error, 1)
+	go func() {
+		s.logger.Printf("dashboard listening on %s", addr)
+		errCh <- srv.ListenAndServe()
+	}()
+	select {
+	case <-ctx.Done():
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if err := srv.Shutdown(shutdownCtx); err != nil {
+			return err
+		}
+		return nil
+	case err := <-errCh:
+		if err == http.ErrServerClosed {
+			return nil
+		}
+		return err
+	}
+}
+
+func (s *Server) handleIndex(w http.ResponseWriter, r *http.Request) {
+	tmpl := template.Must(template.New("index").Parse(indexHTML))
+	if err := tmpl.Execute(w, nil); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+}
+
+func (s *Server) handleRecords(w http.ResponseWriter, r *http.Request) {
+	records, err := s.store.List(r.Context())
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	s.writeJSON(w, records)
+}
+
+func (s *Server) handleRecord(w http.ResponseWriter, r *http.Request) {
+	id := strings.TrimPrefix(r.URL.Path, "/api/records/")
+	if id == "" {
+		http.NotFound(w, r)
+		return
+	}
+	record, err := s.store.Get(r.Context(), id)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusNotFound)
+		return
+	}
+	summary, err := s.store.LoadSummary(r.Context(), id)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	s.writeJSON(w, struct {
+		Record  Record         `json:"record"`
+		Summary report.Summary `json:"summary"`
+	}{Record: record, Summary: summary})
+}
+
+func (s *Server) handleDiff(w http.ResponseWriter, r *http.Request) {
+	query := r.URL.Query()
+	current := query.Get("current")
+	baseline := query.Get("baseline")
+	if current == "" || baseline == "" {
+		http.Error(w, "current and baseline parameters are required", http.StatusBadRequest)
+		return
+	}
+	result, err := s.store.Diff(r.Context(), current, baseline)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	s.writeJSON(w, result)
+}
+
+func (s *Server) writeJSON(w http.ResponseWriter, v interface{}) {
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(v); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+}
+
+const indexHTML = `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<title>Drone Firmware Analyzer Dashboard</title>
+<style>
+body { font-family: sans-serif; margin: 2rem; background: #f5f5f5; }
+header { margin-bottom: 1.5rem; }
+main { display: flex; gap: 2rem; }
+section { background: #fff; padding: 1rem; border-radius: 8px; flex: 1; overflow: auto; max-height: 80vh; }
+ul { list-style: none; padding: 0; }
+li { margin-bottom: 0.5rem; cursor: pointer; }
+li:hover { text-decoration: underline; }
+pre { white-space: pre-wrap; word-break: break-word; }
+label { display: block; margin-top: 0.5rem; }
+select { width: 100%; }
+</style>
+</head>
+<body>
+<header>
+<h1>Drone Firmware Analyzer Dashboard</h1>
+<p>Browse historical analysis runs and compare firmware revisions.</p>
+</header>
+<main>
+<section>
+<h2>Runs</h2>
+<ul id="runs"></ul>
+</section>
+<section>
+<h2>Details</h2>
+<div id="details">Select a run to view summary details.</div>
+<label for="baseline">Compare with baseline:</label>
+<select id="baseline"></select>
+<pre id="diff"></pre>
+</section>
+</main>
+<script>
+async function loadRuns() {
+  const res = await fetch('/api/records');
+  const runs = await res.json();
+  const list = document.getElementById('runs');
+  const baseline = document.getElementById('baseline');
+  list.innerHTML = '';
+  baseline.innerHTML = '<option value="">-- none --</option>';
+  runs.forEach(function(run) {
+    const label = new Date(run.timestamp).toLocaleString() + ' — ' + run.firmware;
+    const li = document.createElement('li');
+    li.textContent = label;
+    li.onclick = function() { showDetails(run.id); };
+    list.appendChild(li);
+    const option = document.createElement('option');
+    option.value = run.id;
+    option.textContent = label;
+    baseline.appendChild(option);
+  });
+  baseline.onchange = function() { updateDiff(currentRecordId, baseline.value); };
+}
+let currentRecordId = '';
+async function showDetails(id) {
+  currentRecordId = id;
+  const res = await fetch('/api/records/' + id);
+  if (!res.ok) {
+    document.getElementById('details').textContent = 'Failed to load run.';
+    return;
+  }
+  const data = await res.json();
+  const summary = data.summary;
+  const record = data.record;
+  const details = document.getElementById('details');
+  const reports = [];
+  ['markdown', 'html', 'json'].forEach(function(key) {
+    const path = record.report_paths[key];
+    if (path) {
+      reports.push('<a href="file://' + path + '">' + key.toUpperCase() + '</a>');
+    }
+  });
+  const reportHtml = reports.length > 0 ? reports.join('<br/>') : 'No reports generated.';
+  details.innerHTML = '<h3>' + summary.firmware + '</h3>' +
+    '<p><strong>Timestamp:</strong> ' + new Date(record.timestamp).toLocaleString() + '</p>' +
+    '<p><strong>Duration:</strong> ' + record.duration + '</p>' +
+    '<p><strong>Reports:</strong><br/>' + reportHtml + '</p>';
+  updateDiff(id, document.getElementById('baseline').value);
+}
+async function updateDiff(current, baseline) {
+  const diffEl = document.getElementById('diff');
+  if (!current || !baseline) {
+    diffEl.textContent = '';
+    return;
+  }
+  const res = await fetch('/api/diff?current=' + encodeURIComponent(current) + '&baseline=' + encodeURIComponent(baseline));
+  if (!res.ok) {
+    diffEl.textContent = 'Failed to load diff.';
+    return;
+  }
+  const data = await res.json();
+  diffEl.textContent = JSON.stringify(data, null, 2);
+}
+loadRuns();
+</script>
+</body>
+</html>`

--- a/pkg/dashboard/store.go
+++ b/pkg/dashboard/store.go
@@ -1,0 +1,255 @@
+package dashboard
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"firmwareanalyzer/pkg/diff"
+	"firmwareanalyzer/pkg/report"
+)
+
+// Record captures metadata about a completed firmware analysis run.
+type Record struct {
+	ID          string       `json:"id"`
+	Firmware    string       `json:"firmware"`
+	Timestamp   time.Time    `json:"timestamp"`
+	Duration    string       `json:"duration"`
+	ReportDir   string       `json:"report_dir,omitempty"`
+	ReportPaths report.Paths `json:"report_paths"`
+	SummaryPath string       `json:"summary_path"`
+	DiffPaths   *diff.Paths  `json:"diff_paths,omitempty"`
+}
+
+// Store exposes read operations for persisted analysis history.
+type Store interface {
+	List(ctx context.Context) ([]Record, error)
+	Get(ctx context.Context, id string) (Record, error)
+	LoadSummary(ctx context.Context, id string) (report.Summary, error)
+	Diff(ctx context.Context, currentID, baselineID string) (diff.Result, error)
+}
+
+// Recorder persists analysis results for future browsing.
+type Recorder interface {
+	Record(ctx context.Context, summary report.Summary, paths report.Paths, diffPaths *diff.Paths, duration time.Duration) (Record, error)
+}
+
+// FileStore stores history entries on disk using one directory per run.
+type FileStore struct {
+	root   string
+	logger *log.Logger
+	mu     sync.Mutex
+}
+
+// NewFileStore initialises a FileStore backed by the supplied directory.
+func NewFileStore(root string, logger *log.Logger) (*FileStore, error) {
+	if strings.TrimSpace(root) == "" {
+		return nil, fmt.Errorf("history directory must be provided")
+	}
+	if logger == nil {
+		logger = log.New(io.Discard, "dashboard", log.LstdFlags)
+	}
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		return nil, err
+	}
+	return &FileStore{root: root, logger: logger}, nil
+}
+
+// Record persists the supplied analysis summary and associated artefacts.
+func (s *FileStore) Record(ctx context.Context, summary report.Summary, paths report.Paths, diffPaths *diff.Paths, duration time.Duration) (Record, error) {
+	if ctx.Err() != nil {
+		return Record{}, ctx.Err()
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	id := fmt.Sprintf("%d", time.Now().UnixNano())
+	recordDir := filepath.Join(s.root, id)
+	if err := os.MkdirAll(recordDir, 0o755); err != nil {
+		return Record{}, err
+	}
+	timestamp := time.Now().UTC()
+
+	summaryPath := filepath.Join(recordDir, "summary.json")
+	if err := s.writeSummary(summary, paths.JSON, summaryPath); err != nil {
+		return Record{}, err
+	}
+
+	storedDiff, err := s.persistDiff(recordDir, diffPaths)
+	if err != nil {
+		return Record{}, err
+	}
+
+	record := Record{
+		ID:          id,
+		Firmware:    summary.Firmware,
+		Timestamp:   timestamp,
+		Duration:    duration.Round(time.Millisecond).String(),
+		ReportDir:   deriveReportDir(paths),
+		ReportPaths: paths,
+		SummaryPath: summaryPath,
+		DiffPaths:   storedDiff,
+	}
+
+	recordData, err := json.MarshalIndent(record, "", "  ")
+	if err != nil {
+		return Record{}, err
+	}
+	if err := os.WriteFile(filepath.Join(recordDir, "record.json"), recordData, 0o644); err != nil {
+		return Record{}, err
+	}
+	s.logger.Printf("history stored %s", id)
+	return record, nil
+}
+
+// List returns all recorded runs ordered by most recent first.
+func (s *FileStore) List(ctx context.Context) ([]Record, error) {
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
+	entries, err := os.ReadDir(s.root)
+	if err != nil {
+		return nil, err
+	}
+	var records []Record
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		rec, err := s.readRecord(filepath.Join(s.root, entry.Name()))
+		if err != nil {
+			s.logger.Printf("skip corrupt record %s: %v", entry.Name(), err)
+			continue
+		}
+		records = append(records, rec)
+	}
+	sort.Slice(records, func(i, j int) bool {
+		return records[i].Timestamp.After(records[j].Timestamp)
+	})
+	return records, nil
+}
+
+// Get retrieves a single record by identifier.
+func (s *FileStore) Get(ctx context.Context, id string) (Record, error) {
+	if ctx.Err() != nil {
+		return Record{}, ctx.Err()
+	}
+	return s.readRecord(filepath.Join(s.root, id))
+}
+
+// LoadSummary loads the stored summary for the given record.
+func (s *FileStore) LoadSummary(ctx context.Context, id string) (report.Summary, error) {
+	if ctx.Err() != nil {
+		return report.Summary{}, ctx.Err()
+	}
+	record, err := s.Get(ctx, id)
+	if err != nil {
+		return report.Summary{}, err
+	}
+	return report.LoadJSON(record.SummaryPath)
+}
+
+// Diff computes the differences between two records.
+func (s *FileStore) Diff(ctx context.Context, currentID, baselineID string) (diff.Result, error) {
+	if ctx.Err() != nil {
+		return diff.Result{}, ctx.Err()
+	}
+	current, err := s.LoadSummary(ctx, currentID)
+	if err != nil {
+		return diff.Result{}, err
+	}
+	baseline, err := s.LoadSummary(ctx, baselineID)
+	if err != nil {
+		return diff.Result{}, err
+	}
+	return diff.Compute(current, baseline), nil
+}
+
+func (s *FileStore) readRecord(dir string) (Record, error) {
+	data, err := os.ReadFile(filepath.Join(dir, "record.json"))
+	if err != nil {
+		return Record{}, err
+	}
+	var record Record
+	if err := json.Unmarshal(data, &record); err != nil {
+		return Record{}, err
+	}
+	if !filepath.IsAbs(record.SummaryPath) {
+		record.SummaryPath = filepath.Join(dir, record.SummaryPath)
+	}
+	if record.DiffPaths != nil {
+		if record.DiffPaths.Markdown != "" && !filepath.IsAbs(record.DiffPaths.Markdown) {
+			record.DiffPaths.Markdown = filepath.Join(dir, record.DiffPaths.Markdown)
+		}
+		if record.DiffPaths.JSON != "" && !filepath.IsAbs(record.DiffPaths.JSON) {
+			record.DiffPaths.JSON = filepath.Join(dir, record.DiffPaths.JSON)
+		}
+	}
+	return record, nil
+}
+
+func (s *FileStore) writeSummary(summary report.Summary, existing, dest string) error {
+	if existing != "" {
+		data, err := os.ReadFile(existing)
+		if err == nil {
+			return os.WriteFile(dest, data, 0o644)
+		}
+		s.logger.Printf("unable to copy existing summary %s: %v", existing, err)
+	}
+	data, err := json.MarshalIndent(summary, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(dest, data, 0o644)
+}
+
+func (s *FileStore) persistDiff(dir string, diffPaths *diff.Paths) (*diff.Paths, error) {
+	if diffPaths == nil {
+		return nil, nil
+	}
+	var stored diff.Paths
+	if diffPaths.Markdown != "" {
+		if err := copyFile(diffPaths.Markdown, filepath.Join(dir, "diff.md")); err != nil {
+			return nil, err
+		}
+		stored.Markdown = filepath.Join(dir, "diff.md")
+	}
+	if diffPaths.JSON != "" {
+		if err := copyFile(diffPaths.JSON, filepath.Join(dir, "diff.json")); err != nil {
+			return nil, err
+		}
+		stored.JSON = filepath.Join(dir, "diff.json")
+	}
+	if stored.Markdown == "" && stored.JSON == "" {
+		return nil, nil
+	}
+	return &stored, nil
+}
+
+func copyFile(src, dest string) error {
+	if src == "" {
+		return nil
+	}
+	data, err := os.ReadFile(src)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(dest, data, 0o644)
+}
+
+func deriveReportDir(paths report.Paths) string {
+	for _, candidate := range []string{paths.Markdown, paths.HTML, paths.JSON} {
+		if candidate != "" {
+			return filepath.Dir(candidate)
+		}
+	}
+	return ""
+}

--- a/pkg/diff/diff.go
+++ b/pkg/diff/diff.go
@@ -1,0 +1,315 @@
+package diff
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"firmwareanalyzer/pkg/binaryinspector"
+	"firmwareanalyzer/pkg/configparser"
+	"firmwareanalyzer/pkg/filesystem"
+	"firmwareanalyzer/pkg/plugin"
+	"firmwareanalyzer/pkg/report"
+	"firmwareanalyzer/pkg/secrets"
+	"firmwareanalyzer/pkg/service"
+	"firmwareanalyzer/pkg/vuln"
+)
+
+// CategoryDiff summarises changes for a particular analysis category.
+type CategoryDiff struct {
+	Added    []string `json:"added,omitempty"`
+	Removed  []string `json:"removed,omitempty"`
+	Modified []string `json:"modified,omitempty"`
+}
+
+// Result aggregates category-level diffs between two firmware reports.
+type Result struct {
+	FirmwareNew     string       `json:"firmware_new"`
+	FirmwareBase    string       `json:"firmware_base"`
+	FileSystems     CategoryDiff `json:"filesystems,omitempty"`
+	Configs         CategoryDiff `json:"configs,omitempty"`
+	Services        CategoryDiff `json:"services,omitempty"`
+	Secrets         CategoryDiff `json:"secrets,omitempty"`
+	Binaries        CategoryDiff `json:"binaries,omitempty"`
+	Vulnerabilities CategoryDiff `json:"vulnerabilities,omitempty"`
+	Plugins         CategoryDiff `json:"plugins,omitempty"`
+}
+
+// Formats specifies which diff artefacts should be written.
+type Formats struct {
+	Markdown bool
+	JSON     bool
+}
+
+// DefaultFormats enables Markdown and JSON outputs.
+var DefaultFormats = Formats{Markdown: true, JSON: true}
+
+// Paths describes the artefacts produced by WriteFiles.
+type Paths struct {
+	Markdown string
+	JSON     string
+}
+
+// Compute calculates the differences between the current summary and a
+// baseline summary.
+func Compute(current, baseline report.Summary) Result {
+	result := Result{
+		FirmwareNew:  current.Firmware,
+		FirmwareBase: baseline.Firmware,
+	}
+	result.FileSystems = diffMaps(filesystemsToMap(current.FileSystems), filesystemsToMap(baseline.FileSystems))
+	result.Configs = diffMaps(configsToMap(current.Configs), configsToMap(baseline.Configs))
+	result.Services = diffMaps(servicesToMap(current.Services), servicesToMap(baseline.Services))
+	result.Secrets = diffMaps(secretsToMap(current.Secrets), secretsToMap(baseline.Secrets))
+	result.Binaries = diffMaps(binariesToMap(current.Binaries), binariesToMap(baseline.Binaries))
+	result.Vulnerabilities = diffMaps(vulnsToMap(current.Vulnerable), vulnsToMap(baseline.Vulnerable))
+	result.Plugins = diffMaps(pluginsToMap(current.Plugins), pluginsToMap(baseline.Plugins))
+	return result
+}
+
+// Markdown renders a Markdown summary of the diff result.
+func (r Result) Markdown() string {
+	var builder strings.Builder
+	builder.WriteString("# Firmware Analysis Diff\n\n")
+	builder.WriteString(fmt.Sprintf("**New firmware:** %s\\n\\n", placeholder(r.FirmwareNew)))
+	builder.WriteString(fmt.Sprintf("**Baseline firmware:** %s\\n\\n", placeholder(r.FirmwareBase)))
+
+	var hasChanges bool
+	if renderCategory(&builder, "Filesystems", r.FileSystems) {
+		hasChanges = true
+	}
+	if renderCategory(&builder, "Configurations", r.Configs) {
+		hasChanges = true
+	}
+	if renderCategory(&builder, "Services", r.Services) {
+		hasChanges = true
+	}
+	if renderCategory(&builder, "Secrets", r.Secrets) {
+		hasChanges = true
+	}
+	if renderCategory(&builder, "Binaries", r.Binaries) {
+		hasChanges = true
+	}
+	if renderCategory(&builder, "Vulnerabilities", r.Vulnerabilities) {
+		hasChanges = true
+	}
+	if renderCategory(&builder, "Plugin Findings", r.Plugins) {
+		hasChanges = true
+	}
+
+	if !hasChanges {
+		builder.WriteString("No differences detected.\n")
+	}
+	return builder.String()
+}
+
+// WriteFiles writes selected diff formats to disk.
+func WriteFiles(result Result, outputDir string, formats Formats) (Paths, error) {
+	if err := os.MkdirAll(outputDir, 0o755); err != nil {
+		return Paths{}, err
+	}
+	if !formats.Markdown && !formats.JSON {
+		formats = DefaultFormats
+	}
+	var paths Paths
+	if formats.Markdown {
+		mdPath := filepath.Join(outputDir, "diff.md")
+		if err := os.WriteFile(mdPath, []byte(result.Markdown()), 0o644); err != nil {
+			return Paths{}, err
+		}
+		paths.Markdown = mdPath
+	}
+	if formats.JSON {
+		data, err := json.MarshalIndent(result, "", "  ")
+		if err != nil {
+			return Paths{}, err
+		}
+		jsonPath := filepath.Join(outputDir, "diff.json")
+		if err := os.WriteFile(jsonPath, data, 0o644); err != nil {
+			return Paths{}, err
+		}
+		paths.JSON = jsonPath
+	}
+	return paths, nil
+}
+
+func renderCategory(builder *strings.Builder, title string, diff CategoryDiff) bool {
+	if len(diff.Added) == 0 && len(diff.Removed) == 0 && len(diff.Modified) == 0 {
+		return false
+	}
+	builder.WriteString(fmt.Sprintf("## %s\n", title))
+	if len(diff.Added) > 0 {
+		builder.WriteString("### Added\n")
+		for _, entry := range diff.Added {
+			builder.WriteString(fmt.Sprintf("- %s\n", entry))
+		}
+		builder.WriteString("\n")
+	}
+	if len(diff.Removed) > 0 {
+		builder.WriteString("### Removed\n")
+		for _, entry := range diff.Removed {
+			builder.WriteString(fmt.Sprintf("- %s\n", entry))
+		}
+		builder.WriteString("\n")
+	}
+	if len(diff.Modified) > 0 {
+		builder.WriteString("### Modified\n")
+		for _, entry := range diff.Modified {
+			builder.WriteString(fmt.Sprintf("- %s\n", entry))
+		}
+		builder.WriteString("\n")
+	}
+	return true
+}
+
+func diffMaps(current, baseline map[string]string) CategoryDiff {
+	diff := CategoryDiff{}
+	for key, value := range current {
+		if old, ok := baseline[key]; !ok {
+			diff.Added = append(diff.Added, fmt.Sprintf("%s = %s", key, value))
+		} else if old != value {
+			diff.Modified = append(diff.Modified, fmt.Sprintf("%s: %s -> %s", key, old, value))
+		}
+	}
+	for key, value := range baseline {
+		if _, ok := current[key]; !ok {
+			diff.Removed = append(diff.Removed, fmt.Sprintf("%s = %s", key, value))
+		}
+	}
+	sort.Strings(diff.Added)
+	sort.Strings(diff.Removed)
+	sort.Strings(diff.Modified)
+	return diff
+}
+
+func filesystemsToMap(mounts []filesystem.Mount) map[string]string {
+	out := make(map[string]string, len(mounts))
+	for _, m := range mounts {
+		details := fmt.Sprintf("%s size=%d offset=%d", placeholder(m.Type), m.Size, m.Offset)
+		if strings.TrimSpace(m.Notes) != "" {
+			details += " notes=" + strings.TrimSpace(m.Notes)
+		}
+		out[placeholder(m.ImagePath)] = details
+	}
+	return out
+}
+
+func configsToMap(cfgs []configparser.Finding) map[string]string {
+	out := make(map[string]string)
+	for _, cfg := range cfgs {
+		for _, param := range cfg.Params {
+			key := fmt.Sprintf("%s (%s)", param.Key, cfg.File)
+			value := param.Value
+			if param.Credential {
+				value += " [credential]"
+			}
+			out[key] = value
+		}
+	}
+	return out
+}
+
+func servicesToMap(services []service.Service) map[string]string {
+	out := make(map[string]string, len(services))
+	for _, svc := range services {
+		key := fmt.Sprintf("%s (%s)", svc.Name, svc.Type)
+		value := strings.TrimSpace(svc.Path)
+		if len(svc.Provides) > 0 {
+			value += " provides=" + strings.Join(svc.Provides, ",")
+		}
+		out[key] = placeholder(value)
+	}
+	return out
+}
+
+func secretsToMap(secrets []secrets.Finding) map[string]string {
+	out := make(map[string]string, len(secrets))
+	for _, sec := range secrets {
+		key := fmt.Sprintf("%s:%d (%s)", sec.File, sec.Line, sec.Rule)
+		value := sec.Match
+		if sec.Entropy > 0 {
+			value += fmt.Sprintf(" entropy=%.2f", sec.Entropy)
+		}
+		out[key] = value
+	}
+	return out
+}
+
+func binariesToMap(binaries []binaryinspector.Result) map[string]string {
+	out := make(map[string]string, len(binaries))
+	for _, bin := range binaries {
+		details := fmt.Sprintf("type=%s arch=%s relro=%s nx=%t pie=%t stripped=%t", placeholder(bin.Type), placeholder(bin.Architecture), strings.ToUpper(string(bin.RELRO)), bin.NXEnabled, bin.PIEEnabled, bin.Stripped)
+		if bin.Interpreter != "" {
+			details += " interp=" + bin.Interpreter
+		}
+		if bin.Err != "" {
+			details += " error=" + bin.Err
+		}
+		out[placeholder(bin.Path)] = details
+	}
+	return out
+}
+
+func vulnsToMap(vulns []vuln.Finding) map[string]string {
+	out := make(map[string]string, len(vulns))
+	for _, finding := range vulns {
+		ids := make([]string, 0, len(finding.CVEs))
+		for _, cve := range finding.CVEs {
+			if cve.ID != "" {
+				ids = append(ids, cve.ID)
+			}
+		}
+		sort.Strings(ids)
+		value := strings.Join(ids, ",")
+		if finding.Error != "" {
+			if value != "" {
+				value += " "
+			}
+			value += "error=" + finding.Error
+		}
+		out[placeholder(finding.Path)] = value
+	}
+	return out
+}
+
+func pluginsToMap(results []plugin.Result) map[string]string {
+	out := make(map[string]string)
+	for _, res := range results {
+		if res.Error != "" {
+			key := fmt.Sprintf("%s (error)", res.Plugin)
+			out[key] = res.Error
+		}
+		for _, finding := range res.Findings {
+			key := fmt.Sprintf("%s: %s", res.Plugin, finding.Summary)
+			value := strings.TrimSpace(finding.Severity)
+			if value == "" {
+				value = "info"
+			}
+			if len(finding.Details) > 0 {
+				keys := make([]string, 0, len(finding.Details))
+				for k := range finding.Details {
+					keys = append(keys, k)
+				}
+				sort.Strings(keys)
+				var pairs []string
+				for _, k := range keys {
+					pairs = append(pairs, fmt.Sprintf("%s=%v", k, finding.Details[k]))
+				}
+				value += " " + strings.Join(pairs, ";")
+			}
+			out[key] = value
+		}
+	}
+	return out
+}
+
+func placeholder(value string) string {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return "-"
+	}
+	return trimmed
+}

--- a/pkg/extractor/extractor.go
+++ b/pkg/extractor/extractor.go
@@ -1,0 +1,595 @@
+package extractor
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"firmwareanalyzer/pkg/utils"
+)
+
+// Partition describes a logical filesystem extracted from a firmware image.
+type Partition struct {
+	Name        string  `json:"name"`
+	Path        string  `json:"path"`
+	Type        string  `json:"type"`
+	Size        int64   `json:"size"`
+	Offset      int64   `json:"offset,omitempty"`
+	Notes       string  `json:"notes,omitempty"`
+	Entropy     float64 `json:"entropy,omitempty"`
+	Compression string  `json:"compression,omitempty"`
+}
+
+// Result holds metadata about an extraction run.
+type Result struct {
+	Firmware   string      `json:"firmware"`
+	OutputDir  string      `json:"output_dir"`
+	Started    time.Time   `json:"started"`
+	Completed  time.Time   `json:"completed"`
+	Partitions []Partition `json:"partitions"`
+}
+
+// Options configure the Extractor behaviour.
+type Options struct {
+	WorkDir            string
+	PreserveTemp       bool
+	ExternalExtractors []string
+}
+
+// Extractor performs firmware extraction using built-in archive handlers and
+// optional external tooling.
+type Extractor struct {
+	opts   Options
+	logger *log.Logger
+}
+
+// New creates an Extractor with the supplied options. If logger is nil it is
+// replaced with a silent logger.
+func New(opts Options, logger *log.Logger) *Extractor {
+	if logger == nil {
+		logger = log.New(io.Discard, "extractor", log.LstdFlags)
+	}
+	if opts.ExternalExtractors == nil {
+		opts.ExternalExtractors = []string{"unblob", "binwalk"}
+	}
+	return &Extractor{opts: opts, logger: logger}
+}
+
+// Extract expands the supplied firmware image into a working directory and
+// returns metadata about any detected partitions. The function supports
+// tarballs (optionally gzip compressed), zip archives, and already extracted
+// directory trees.
+func (e *Extractor) Extract(ctx context.Context, firmwarePath string) (*Result, error) {
+	info, err := os.Stat(firmwarePath)
+	if err != nil {
+		return nil, fmt.Errorf("stat firmware: %w", err)
+	}
+
+	workDir := e.opts.WorkDir
+	if workDir == "" {
+		workDir, err = os.MkdirTemp("", "fw-extract-*")
+		if err != nil {
+			return nil, fmt.Errorf("create temp dir: %w", err)
+		}
+	} else {
+		if err := os.MkdirAll(workDir, 0o755); err != nil {
+			return nil, fmt.Errorf("create workdir: %w", err)
+		}
+		workDir, err = os.MkdirTemp(workDir, "fw-")
+		if err != nil {
+			return nil, fmt.Errorf("create nested temp dir: %w", err)
+		}
+	}
+
+	res := &Result{
+		Firmware:  firmwarePath,
+		OutputDir: workDir,
+		Started:   time.Now(),
+	}
+
+	cleanup := func() {
+		if e.opts.PreserveTemp {
+			return
+		}
+		if err != nil {
+			_ = os.RemoveAll(workDir)
+		}
+	}
+	defer cleanup()
+
+	switch {
+	case info.IsDir():
+		if err = copyDir(ctx, firmwarePath, workDir); err != nil {
+			return nil, err
+		}
+	default:
+		var usedExternal bool
+		usedExternal, err = e.tryExternal(ctx, firmwarePath, workDir)
+		if err != nil {
+			return nil, err
+		}
+		if !usedExternal {
+			ext := strings.ToLower(filepath.Ext(info.Name()))
+			switch ext {
+			case ".gz", ".tgz", ".tar":
+				if err = extractTar(ctx, firmwarePath, workDir); err != nil {
+					return nil, err
+				}
+			case ".zip":
+				if err = extractZip(ctx, firmwarePath, workDir); err != nil {
+					return nil, err
+				}
+			default:
+				return nil, fmt.Errorf("unsupported firmware format: %s", firmwarePath)
+			}
+		}
+	}
+
+	root := normalizeRoot(workDir)
+	res.OutputDir = root
+
+	var partitions []Partition
+	partitions, err = discoverPartitions(root)
+	if err != nil {
+		return nil, err
+	}
+	res.Partitions = partitions
+	res.Completed = time.Now()
+	return res, nil
+}
+
+func copyDir(ctx context.Context, src, dst string) error {
+	return filepath.WalkDir(src, func(path string, d os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		rel, err := filepath.Rel(src, path)
+		if err != nil {
+			return err
+		}
+		target := filepath.Join(dst, rel)
+		if d.IsDir() {
+			return os.MkdirAll(target, 0o755)
+		}
+
+		info, err := d.Info()
+		if err != nil {
+			return err
+		}
+
+		if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+			return err
+		}
+
+		in, err := os.Open(path)
+		if err != nil {
+			return err
+		}
+		out, err := os.OpenFile(target, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, info.Mode())
+		if err != nil {
+			in.Close()
+			return err
+		}
+		if _, err := io.Copy(out, in); err != nil {
+			out.Close()
+			in.Close()
+			return err
+		}
+		out.Close()
+		in.Close()
+		return nil
+	})
+}
+
+func extractTar(ctx context.Context, src, dst string) error {
+	file, err := os.Open(src)
+	if err != nil {
+		return fmt.Errorf("open tar: %w", err)
+	}
+	defer file.Close()
+
+	var reader io.Reader = file
+	lower := strings.ToLower(src)
+	if strings.HasSuffix(lower, ".gz") || strings.HasSuffix(lower, ".tgz") {
+		gz, err := gzip.NewReader(file)
+		if err != nil {
+			return fmt.Errorf("gzip reader: %w", err)
+		}
+		defer gz.Close()
+		reader = gz
+	}
+
+	tarReader := tar.NewReader(reader)
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		header, err := tarReader.Next()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("tar next: %w", err)
+		}
+		target := filepath.Join(dst, header.Name)
+		switch header.Typeflag {
+		case tar.TypeDir:
+			if err := os.MkdirAll(target, os.FileMode(header.Mode)); err != nil {
+				return fmt.Errorf("mkdir %s: %w", target, err)
+			}
+		case tar.TypeReg, tar.TypeRegA:
+			if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+				return err
+			}
+			out, err := os.OpenFile(target, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, os.FileMode(header.Mode))
+			if err != nil {
+				return fmt.Errorf("create %s: %w", target, err)
+			}
+			if _, err := io.Copy(out, tarReader); err != nil {
+				out.Close()
+				return fmt.Errorf("copy %s: %w", target, err)
+			}
+			out.Close()
+		}
+	}
+	return nil
+}
+
+func extractZip(ctx context.Context, src, dst string) error {
+	reader, err := zip.OpenReader(src)
+	if err != nil {
+		return fmt.Errorf("open zip: %w", err)
+	}
+	defer reader.Close()
+
+	for _, file := range reader.File {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		target := filepath.Join(dst, file.Name)
+		if file.FileInfo().IsDir() {
+			if err := os.MkdirAll(target, file.Mode()); err != nil {
+				return err
+			}
+			continue
+		}
+
+		if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+			return err
+		}
+
+		rc, err := file.Open()
+		if err != nil {
+			return err
+		}
+		out, err := os.OpenFile(target, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, file.Mode())
+		if err != nil {
+			rc.Close()
+			return err
+		}
+		if _, err := io.Copy(out, rc); err != nil {
+			out.Close()
+			rc.Close()
+			return err
+		}
+		out.Close()
+		rc.Close()
+	}
+
+	return nil
+}
+
+func (e *Extractor) tryExternal(ctx context.Context, firmwarePath, outputDir string) (bool, error) {
+	for _, tool := range e.opts.ExternalExtractors {
+		if strings.TrimSpace(tool) == "" {
+			continue
+		}
+		ok, err := e.runExternal(ctx, tool, firmwarePath, outputDir)
+		if err != nil {
+			if errors.Is(err, context.Canceled) {
+				return false, err
+			}
+			e.logger.Printf("external extractor %s failed: %v", tool, err)
+			continue
+		}
+		if ok {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func (e *Extractor) runExternal(ctx context.Context, tool, firmwarePath, outputDir string) (bool, error) {
+	if strings.TrimSpace(tool) == "" {
+		return false, nil
+	}
+	path, err := exec.LookPath(tool)
+	if err != nil {
+		return false, nil
+	}
+	var args []string
+	switch filepath.Base(path) {
+	case "unblob":
+		args = []string{"--extract-dir", outputDir, firmwarePath}
+	case "binwalk":
+		args = []string{"--extract", "--directory", outputDir, firmwarePath}
+	default:
+		return false, fmt.Errorf("unsupported external extractor: %s", tool)
+	}
+	cmd := exec.CommandContext(ctx, path, args...)
+	cmd.Stdout = io.Discard
+	cmd.Stderr = io.Discard
+	if err := cmd.Run(); err != nil {
+		return false, fmt.Errorf("run %s: %w", tool, err)
+	}
+	return true, nil
+}
+
+func normalizeRoot(dir string) string {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return dir
+	}
+	if len(entries) != 1 {
+		return dir
+	}
+	entry := entries[0]
+	if !entry.IsDir() {
+		return dir
+	}
+	name := strings.ToLower(entry.Name())
+	if strings.Contains(name, "extract") || strings.HasSuffix(name, "-root") || strings.HasSuffix(name, "_root") {
+		return filepath.Join(dir, entry.Name())
+	}
+	return dir
+}
+
+func discoverPartitions(root string) ([]Partition, error) {
+	var parts []Partition
+	seenDirs := make(map[string]struct{})
+	err := filepath.WalkDir(root, func(path string, d os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if path == root {
+			return nil
+		}
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			if strings.Contains(rel, string(os.PathSeparator)) {
+				return nil
+			}
+			if !utils.LooksLikeRoot(path) {
+				return nil
+			}
+			if _, seen := seenDirs[rel]; seen {
+				return nil
+			}
+			info, err := d.Info()
+			if err != nil {
+				return err
+			}
+			seenDirs[rel] = struct{}{}
+			parts = append(parts, Partition{
+				Name:        rel,
+				Path:        path,
+				Type:        "directory",
+				Size:        info.Size(),
+				Notes:       "contains system directories",
+				Compression: "n/a",
+			})
+			return nil
+		}
+
+		info, err := d.Info()
+		if err != nil {
+			return err
+		}
+		partType, offset, notes, err := classifyPartition(path)
+		if err != nil {
+			return err
+		}
+		if partType == "" {
+			return nil
+		}
+		entropy, entropyErr := utils.SampleFileEntropy(path, 0)
+		if entropyErr != nil {
+			// Entropy calculation failures should not abort
+			// partition discovery; surface the message in notes
+			// for operator awareness.
+			if notes == "" {
+				notes = entropyErr.Error()
+			} else {
+				notes = notes + "; entropy: " + entropyErr.Error()
+			}
+			entropy = 0
+		}
+		parts = append(parts, Partition{
+			Name:        rel,
+			Path:        path,
+			Type:        partType,
+			Size:        info.Size(),
+			Offset:      offset,
+			Notes:       notes,
+			Entropy:     entropy,
+			Compression: compressionCategory(entropy),
+		})
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	sort.Slice(parts, func(i, j int) bool { return parts[i].Name < parts[j].Name })
+	return parts, nil
+}
+
+func compressionCategory(entropy float64) string {
+	switch {
+	case entropy == 0:
+		return "unknown"
+	case entropy >= 7.5:
+		return "high"
+	case entropy >= 6.0:
+		return "medium"
+	default:
+		return "low"
+	}
+}
+
+func classifyPartition(path string) (string, int64, string, error) {
+	ext := strings.ToLower(filepath.Ext(path))
+	switch ext {
+	case ".squashfs", ".sqsh":
+		return "squashfs", 0, "detected via extension", nil
+	case ".ubi":
+		return "ubi", 0, "detected via extension", nil
+	case ".ext", ".ext2", ".ext3", ".ext4":
+		return "ext", 0, "detected via extension", nil
+	}
+
+	file, err := os.Open(path)
+	if err != nil {
+		return "", 0, "", fmt.Errorf("open partition: %w", err)
+	}
+	defer file.Close()
+
+	header := make([]byte, 4)
+	if _, err := io.ReadFull(file, header); err == nil {
+		switch string(header) {
+		case "hsqs", "sqsh":
+			return "squashfs", 0, "magic matched", nil
+		case "UBI#", "UBI!":
+			return "ubi", 0, "magic matched", nil
+		}
+	}
+
+	if _, err := file.Seek(0x438, io.SeekStart); err == nil {
+		var extMagic uint16
+		if err := binary.Read(file, binary.LittleEndian, &extMagic); err == nil && extMagic == 0xEF53 {
+			return "ext", 0, "superblock magic matched", nil
+		}
+	}
+
+	if ok, offset, notes, err := probeGPT(file); err != nil {
+		return "", 0, "", err
+	} else if ok {
+		return "gpt", offset, notes, nil
+	}
+
+	if ok, notes, err := probeMTD(file); err != nil {
+		return "", 0, "", err
+	} else if ok {
+		return "mtd", 0, notes, nil
+	}
+
+	return "", 0, "", nil
+}
+
+func probeGPT(file *os.File) (bool, int64, string, error) {
+	if _, err := file.Seek(0, io.SeekEnd); err != nil {
+		return false, 0, "", err
+	}
+	size, err := file.Seek(0, io.SeekCurrent)
+	if err != nil {
+		return false, 0, "", err
+	}
+	if size < 0x400 {
+		return false, 0, "", nil
+	}
+	if _, err := file.Seek(0x200, io.SeekStart); err != nil {
+		return false, 0, "", err
+	}
+	var header struct {
+		Signature           [8]byte
+		Revision            uint32
+		HeaderSize          uint32
+		CRC32               uint32
+		Reserved            uint32
+		CurrentLBA          uint64
+		BackupLBA           uint64
+		FirstUsableLBA      uint64
+		LastUsableLBA       uint64
+		DiskGUID            [16]byte
+		PartitionEntryLBA   uint64
+		NumPartitionEntries uint32
+		PartitionEntrySize  uint32
+		PartitionArrayCRC32 uint32
+	}
+	if err := binary.Read(file, binary.LittleEndian, &header); err != nil {
+		return false, 0, "", nil
+	}
+	if !bytes.Equal(header.Signature[:], []byte("EFI PART")) {
+		return false, 0, "", nil
+	}
+	entryOffset := int64(header.PartitionEntryLBA) * 512
+	if entryOffset <= 0 {
+		return true, 0, "GPT header detected", nil
+	}
+	if _, err := file.Seek(entryOffset, io.SeekStart); err != nil {
+		return true, 0, "GPT header detected", nil
+	}
+	entrySize := int64(header.PartitionEntrySize)
+	if entrySize < 32 {
+		entrySize = 128
+	}
+	entry := make([]byte, entrySize)
+	if _, err := io.ReadFull(file, entry); err != nil {
+		return true, 0, "GPT header detected", nil
+	}
+	if bytes.Equal(entry[:16], make([]byte, 16)) {
+		return true, 0, "GPT present without populated entries", nil
+	}
+	firstLBA := binary.LittleEndian.Uint64(entry[32:40])
+	lastLBA := binary.LittleEndian.Uint64(entry[40:48])
+	nameBytes := bytes.Trim(entry[56:], "\x00")
+	name := strings.TrimSpace(string(nameBytes))
+	if name == "" {
+		name = "unnamed"
+	}
+	notes := fmt.Sprintf("GPT partition %s (%d-%d)", name, firstLBA, lastLBA)
+	return true, int64(firstLBA) * 512, notes, nil
+}
+
+func probeMTD(file *os.File) (bool, string, error) {
+	if _, err := file.Seek(0, io.SeekStart); err != nil {
+		return false, "", err
+	}
+	buf := make([]byte, 64*1024)
+	n, err := file.Read(buf)
+	if err != nil && !errors.Is(err, io.EOF) {
+		return false, "", err
+	}
+	buf = buf[:n]
+	if bytes.Contains(buf, []byte("mtdparts=")) {
+		return true, "contains mtdparts definition", nil
+	}
+	return false, "", nil
+}

--- a/pkg/filesystem/filesystem.go
+++ b/pkg/filesystem/filesystem.go
@@ -1,0 +1,243 @@
+package filesystem
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"firmwareanalyzer/pkg/utils"
+)
+
+// Mount represents a filesystem image or directory detected within an
+// extracted firmware tree.
+type Mount struct {
+	ImagePath  string `json:"image_path"`
+	MountPoint string `json:"mount_point"`
+	Type       string `json:"type"`
+	Size       int64  `json:"size"`
+	Offset     int64  `json:"offset,omitempty"`
+	Notes      string `json:"notes,omitempty"`
+}
+
+// Detector provides lightweight filesystem detection heuristics for common
+// embedded formats without performing privileged mounts.
+type Detector struct {
+	logger   *log.Logger
+	maxProbe int64
+}
+
+// NewDetector returns a Detector that probes up to 4MiB of each candidate file.
+func NewDetector(logger *log.Logger) *Detector {
+	if logger == nil {
+		logger = log.New(io.Discard, "filesystem", log.LstdFlags)
+	}
+	return &Detector{logger: logger, maxProbe: 4 << 20}
+}
+
+// Detect walks the supplied root directory looking for filesystem images.
+// Directories are treated as already extracted mounts and files are inspected
+// for SquashFS, UBI and ext4 signatures.
+func (d *Detector) Detect(ctx context.Context, root string) ([]Mount, error) {
+	var mounts []Mount
+	err := filepath.WalkDir(root, func(path string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+		if path == root {
+			return nil
+		}
+		if entry.IsDir() {
+			if !utils.LooksLikeRoot(path) {
+				return nil
+			}
+			info, err := entry.Info()
+			if err != nil {
+				return err
+			}
+			mounts = append(mounts, Mount{
+				ImagePath:  path,
+				MountPoint: path,
+				Type:       "directory",
+				Size:       info.Size(),
+				Notes:      "contains system directories",
+			})
+			return nil
+		}
+
+		info, err := entry.Info()
+		if err != nil {
+			return err
+		}
+		mntType, notes, offset, err := d.classify(path)
+		if err != nil {
+			return err
+		}
+		if mntType == "" {
+			return nil
+		}
+		mounts = append(mounts, Mount{
+			ImagePath:  path,
+			MountPoint: "",
+			Type:       mntType,
+			Size:       info.Size(),
+			Offset:     offset,
+			Notes:      notes,
+		})
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	sort.Slice(mounts, func(i, j int) bool { return mounts[i].ImagePath < mounts[j].ImagePath })
+	return mounts, nil
+}
+
+func (d *Detector) classify(path string) (string, string, int64, error) {
+	ext := strings.ToLower(filepath.Ext(path))
+	switch ext {
+	case ".squashfs", ".sqsh":
+		return "squashfs", "detected via file extension", 0, nil
+	case ".ubi":
+		return "ubi", "detected via file extension", 0, nil
+	case ".ext", ".ext2", ".ext3", ".ext4":
+		return "ext", "detected via file extension", 0, nil
+	}
+
+	file, err := os.Open(path)
+	if err != nil {
+		return "", "", 0, fmt.Errorf("open image: %w", err)
+	}
+	defer file.Close()
+
+	magic := make([]byte, 4)
+	if _, err := io.ReadFull(file, magic); err != nil {
+		return "", "", 0, nil
+	}
+
+	switch {
+	case string(magic) == "hsqs" || string(magic) == "sqsh":
+		return "squashfs", "magic matched", 0, nil
+	case string(magic) == "UBI#" || string(magic) == "UBI!":
+		return "ubi", "magic matched", 0, nil
+	}
+
+	// ext4 magic resides at offset 0x438
+	if _, err := file.Seek(0x438, io.SeekStart); err == nil {
+		var extMagic uint16
+		if err := binary.Read(file, binary.LittleEndian, &extMagic); err == nil && extMagic == 0xEF53 {
+			return "ext", "magic matched", 0, nil
+		}
+	}
+	if ok, offset, notes, err := probeGPT(file); err != nil {
+		return "", "", 0, err
+	} else if ok {
+		return "gpt", notes, offset, nil
+	}
+	if ok, notes, err := probeMTD(file, d.maxProbe); err != nil {
+		return "", "", 0, err
+	} else if ok {
+		return "mtd", notes, 0, nil
+	}
+	return "", "", 0, nil
+}
+
+func probeGPT(file *os.File) (bool, int64, string, error) {
+	if _, err := file.Seek(0, io.SeekEnd); err != nil {
+		return false, 0, "", err
+	}
+	size, err := file.Seek(0, io.SeekCurrent)
+	if err != nil {
+		return false, 0, "", err
+	}
+	if size < 0x400 {
+		return false, 0, "", nil
+	}
+	if _, err := file.Seek(0x200, io.SeekStart); err != nil {
+		return false, 0, "", err
+	}
+	var header struct {
+		Signature           [8]byte
+		Revision            uint32
+		HeaderSize          uint32
+		CRC32               uint32
+		Reserved            uint32
+		CurrentLBA          uint64
+		BackupLBA           uint64
+		FirstUsableLBA      uint64
+		LastUsableLBA       uint64
+		DiskGUID            [16]byte
+		PartitionEntryLBA   uint64
+		NumPartitionEntries uint32
+		PartitionEntrySize  uint32
+		PartitionArrayCRC32 uint32
+	}
+	if err := binary.Read(file, binary.LittleEndian, &header); err != nil {
+		return false, 0, "", nil
+	}
+	if !bytes.Equal(header.Signature[:], []byte("EFI PART")) {
+		return false, 0, "", nil
+	}
+	entryOffset := int64(header.PartitionEntryLBA) * 512
+	if entryOffset <= 0 {
+		return true, 0, "GPT header detected", nil
+	}
+	if _, err := file.Seek(entryOffset, io.SeekStart); err != nil {
+		return true, 0, "GPT header detected", nil
+	}
+	entrySize := int64(header.PartitionEntrySize)
+	if entrySize < 32 {
+		entrySize = 128
+	}
+	entry := make([]byte, entrySize)
+	if _, err := io.ReadFull(file, entry); err != nil {
+		return true, 0, "GPT header detected", nil
+	}
+	if len(entry) < 56 {
+		return true, 0, "GPT header detected", nil
+	}
+	if bytes.Equal(entry[:16], make([]byte, 16)) {
+		return true, 0, "GPT present without populated entries", nil
+	}
+	firstLBA := binary.LittleEndian.Uint64(entry[32:40])
+	lastLBA := binary.LittleEndian.Uint64(entry[40:48])
+	nameBytes := bytes.Trim(entry[56:], "\x00")
+	name := strings.TrimSpace(string(nameBytes))
+	if name == "" {
+		name = "unnamed"
+	}
+	notes := fmt.Sprintf("GPT partition %s (%d-%d)", name, firstLBA, lastLBA)
+	return true, int64(firstLBA) * 512, notes, nil
+}
+
+func probeMTD(file *os.File, max int64) (bool, string, error) {
+	if _, err := file.Seek(0, io.SeekStart); err != nil {
+		return false, "", err
+	}
+	bufSize := max
+	if bufSize <= 0 || bufSize > 64*1024 {
+		bufSize = 64 * 1024
+	}
+	buf := make([]byte, bufSize)
+	n, err := file.Read(buf)
+	if err != nil && !errors.Is(err, io.EOF) {
+		return false, "", err
+	}
+	buf = buf[:n]
+	if bytes.Contains(buf, []byte("mtdparts=")) {
+		return true, "contains mtdparts definition", nil
+	}
+	return false, "", nil
+}

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -1,0 +1,216 @@
+package plugin
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"firmwareanalyzer/pkg/binaryinspector"
+	"firmwareanalyzer/pkg/configparser"
+	"firmwareanalyzer/pkg/extractor"
+	"firmwareanalyzer/pkg/filesystem"
+	"firmwareanalyzer/pkg/secrets"
+	"firmwareanalyzer/pkg/service"
+	"firmwareanalyzer/pkg/vuln"
+)
+
+// Finding represents a single plugin-reported issue.
+type Finding struct {
+	Plugin   string         `json:"plugin"`
+	Summary  string         `json:"summary"`
+	Severity string         `json:"severity,omitempty"`
+	Details  map[string]any `json:"details,omitempty"`
+}
+
+// Result captures the outcome of running a plugin executable.
+type Result struct {
+	Plugin   string    `json:"plugin"`
+	Findings []Finding `json:"findings,omitempty"`
+	Error    string    `json:"error,omitempty"`
+}
+
+// Options tune plugin discovery and execution.
+type Options struct {
+	Directory      string
+	Timeout        time.Duration
+	Env            map[string]string
+	MaxOutputBytes int64
+}
+
+// Runner executes external plugin scripts and collects JSON-formatted findings.
+type Runner struct {
+	logger *log.Logger
+	opts   Options
+}
+
+// NewRunner instantiates a Runner, discarding logs when logger is nil.
+func NewRunner(logger *log.Logger, opts Options) *Runner {
+	if logger == nil {
+		logger = log.New(io.Discard, "plugin", log.LstdFlags)
+	}
+	if opts.Timeout == 0 {
+		opts.Timeout = 30 * time.Second
+	}
+	if opts.MaxOutputBytes <= 0 {
+		opts.MaxOutputBytes = 1 << 20 // 1MiB default stdout cap
+	}
+	return &Runner{logger: logger, opts: opts}
+}
+
+// Metadata summarises the workspace for plugins. It is serialised to JSON and
+// provided on stdin to each plugin invocation so that external checks can make
+// informed decisions without re-scanning the filesystem.
+type Metadata struct {
+	Firmware        string                   `json:"firmware"`
+	Root            string                   `json:"root"`
+	Partitions      []extractor.Partition    `json:"partitions,omitempty"`
+	FileSystems     []filesystem.Mount       `json:"filesystems,omitempty"`
+	Configs         []configparser.Finding   `json:"configs,omitempty"`
+	Services        []service.Service        `json:"services,omitempty"`
+	Secrets         []secrets.Finding        `json:"secrets,omitempty"`
+	Binaries        []binaryinspector.Result `json:"binaries,omitempty"`
+	Vulnerabilities []vuln.Finding           `json:"vulnerabilities,omitempty"`
+}
+
+// Run executes each executable file within the configured directory, treating
+// stdout as a JSON array of findings. Structured workspace metadata is provided
+// to plugins via stdin as JSON. Errors encountered while running or decoding a
+// plugin are captured in the corresponding Result.Error field.
+func (r *Runner) Run(ctx context.Context, meta Metadata) ([]Result, error) {
+	if strings.TrimSpace(r.opts.Directory) == "" {
+		return nil, nil
+	}
+	entries, err := os.ReadDir(r.opts.Directory)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read plugin dir: %w", err)
+	}
+	sort.Slice(entries, func(i, j int) bool { return entries[i].Name() < entries[j].Name() })
+
+	payload, err := json.Marshal(meta)
+	if err != nil {
+		return nil, fmt.Errorf("encode metadata: %w", err)
+	}
+
+	var results []Result
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		info, err := entry.Info()
+		if err != nil {
+			r.logger.Printf("stat plugin %s: %v", entry.Name(), err)
+			continue
+		}
+		if info.Mode()&0o111 == 0 {
+			continue
+		}
+		path := filepath.Join(r.opts.Directory, entry.Name())
+		result := r.runPlugin(ctx, path, payload, meta.Root)
+		results = append(results, result)
+	}
+	return results, nil
+}
+
+func (r *Runner) runPlugin(ctx context.Context, path string, payload []byte, root string) Result {
+	name := filepath.Base(path)
+	ctx, cancel := context.WithTimeout(ctx, r.opts.Timeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, path)
+	cmd.Env = append(os.Environ(), "ANALYZER_ROOT="+root)
+	for key, value := range r.opts.Env {
+		cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", key, value))
+	}
+	cmd.Env = append(cmd.Env, "ANALYZER_METADATA_FORMAT=json")
+	cmd.Stdin = bytes.NewReader(payload)
+
+	stdout := newLimitedBuffer(r.opts.MaxOutputBytes)
+	stderr := newLimitedBuffer(128 << 10)
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
+
+	err := cmd.Run()
+	if err != nil {
+		msg := err.Error()
+		if stderr.Len() > 0 {
+			msg = fmt.Sprintf("%s: %s", msg, strings.TrimSpace(stderr.String()))
+		}
+		if stderr.Truncated() {
+			msg += " (stderr truncated)"
+		}
+		return Result{Plugin: name, Error: msg}
+	}
+
+	if stdout.Len() == 0 {
+		return Result{Plugin: name}
+	}
+
+	if stdout.Truncated() {
+		return Result{Plugin: name, Error: "stdout truncated"}
+	}
+
+	var findings []Finding
+	if decodeErr := json.NewDecoder(bytes.NewReader(stdout.Bytes())).Decode(&findings); decodeErr != nil {
+		return Result{Plugin: name, Error: fmt.Sprintf("decode JSON: %v", decodeErr)}
+	}
+	for i := range findings {
+		findings[i].Plugin = name
+	}
+	return Result{Plugin: name, Findings: findings}
+}
+
+type limitedBuffer struct {
+	buf       bytes.Buffer
+	max       int64
+	truncated bool
+}
+
+func newLimitedBuffer(max int64) *limitedBuffer {
+	return &limitedBuffer{max: max}
+}
+
+func (b *limitedBuffer) Write(p []byte) (int, error) {
+	if b.max <= 0 {
+		return b.buf.Write(p)
+	}
+	if int64(b.buf.Len()+len(p)) <= b.max {
+		return b.buf.Write(p)
+	}
+	allowed := int(b.max) - b.buf.Len()
+	if allowed < 0 {
+		allowed = 0
+	}
+	if allowed > 0 {
+		b.buf.Write(p[:allowed])
+	}
+	b.truncated = true
+	return len(p), nil
+}
+
+func (b *limitedBuffer) Len() int {
+	return b.buf.Len()
+}
+
+func (b *limitedBuffer) Bytes() []byte {
+	return b.buf.Bytes()
+}
+
+func (b *limitedBuffer) String() string {
+	return b.buf.String()
+}
+
+func (b *limitedBuffer) Truncated() bool {
+	return b.truncated
+}

--- a/pkg/report/report.go
+++ b/pkg/report/report.go
@@ -1,0 +1,336 @@
+package report
+
+import (
+	"encoding/json"
+	"fmt"
+	"html/template"
+	"io"
+	"log"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"firmwareanalyzer/pkg/binaryinspector"
+	"firmwareanalyzer/pkg/configparser"
+	"firmwareanalyzer/pkg/extractor"
+	"firmwareanalyzer/pkg/filesystem"
+	"firmwareanalyzer/pkg/plugin"
+	"firmwareanalyzer/pkg/sbom"
+	"firmwareanalyzer/pkg/secrets"
+	"firmwareanalyzer/pkg/service"
+	"firmwareanalyzer/pkg/vuln"
+)
+
+// Summary aggregates analysis results for rendering.
+type Summary struct {
+        Firmware    string
+        Extraction  *extractor.Result
+        FileSystems []filesystem.Mount
+        Configs     []configparser.Finding
+        Services    []service.Service
+        Secrets     []secrets.Finding
+        Binaries    []binaryinspector.Result
+        Vulnerable  []vuln.Finding
+        SBOM        *sbom.Document
+        SBOMPath    string
+        SBOMPaths   []string
+        SBOMSignatures []string
+        Plugins     []plugin.Result
+}
+
+// Generator renders Markdown and HTML reports.
+type Generator struct {
+	logger *log.Logger
+}
+
+// NewGenerator returns a generator that discards log output when logger is nil.
+func NewGenerator(logger *log.Logger) *Generator {
+	if logger == nil {
+		logger = log.New(io.Discard, "report", log.LstdFlags)
+	}
+	return &Generator{logger: logger}
+}
+
+// Markdown produces a Markdown report summarising the supplied analysis.
+func (g *Generator) Markdown(summary Summary) string {
+	var builder strings.Builder
+	builder.WriteString("# Drone Firmware Analyzer Report\n\n")
+	builder.WriteString(fmt.Sprintf("**Firmware:** %s\n\n", summary.Firmware))
+
+	if summary.Extraction != nil {
+		builder.WriteString("## Extraction\n")
+		builder.WriteString(fmt.Sprintf("Output directory: `%s`\n\n", summary.Extraction.OutputDir))
+		if len(summary.Extraction.Partitions) > 0 {
+			builder.WriteString("| Name | Type | Size (bytes) | Offset | Entropy | Compression | Notes | Path |\n")
+			builder.WriteString("| --- | --- | --- | --- | --- | --- | --- | --- |\n")
+			for _, part := range summary.Extraction.Partitions {
+				offset := "-"
+				if part.Offset > 0 {
+					offset = fmt.Sprintf("%d", part.Offset)
+				}
+				entropy := "-"
+				if part.Entropy > 0 {
+					entropy = fmt.Sprintf("%.2f", part.Entropy)
+				}
+				compression := part.Compression
+				if compression == "" {
+					compression = "-"
+				}
+				notes := part.Notes
+				if notes == "" {
+					notes = "-"
+				}
+				builder.WriteString(fmt.Sprintf("| %s | %s | %d | %s | %s | %s | %s | %s |\n", part.Name, part.Type, part.Size, offset, entropy, compression, notes, part.Path))
+			}
+			builder.WriteString("\n")
+		}
+	}
+
+	if len(summary.FileSystems) > 0 {
+		builder.WriteString("## Filesystems\n")
+		builder.WriteString("| Image | Type | Size (bytes) | Offset | Notes |\n")
+		builder.WriteString("| --- | --- | --- | --- | --- |\n")
+		for _, fs := range summary.FileSystems {
+			offset := "-"
+			if fs.Offset > 0 {
+				offset = fmt.Sprintf("%d", fs.Offset)
+			}
+			notes := fs.Notes
+			if notes == "" {
+				notes = "-"
+			}
+			builder.WriteString(fmt.Sprintf("| %s | %s | %d | %s | %s |\n", fs.ImagePath, fs.Type, fs.Size, offset, notes))
+		}
+		builder.WriteString("\n")
+	}
+
+	if len(summary.Configs) > 0 {
+		builder.WriteString("## Configuration Findings\n")
+		for _, cfg := range summary.Configs {
+			builder.WriteString(fmt.Sprintf("### %s (%s)\n", cfg.File, strings.ToUpper(cfg.Format)))
+			builder.WriteString("| Key | Value | Credential? |\n")
+			builder.WriteString("| --- | --- | --- |\n")
+			for _, param := range cfg.Params {
+				cred := ""
+				if param.Credential {
+					cred = "⚠️"
+				}
+				builder.WriteString(fmt.Sprintf("| %s | %s | %s |\n", param.Key, param.Value, cred))
+			}
+			builder.WriteString("\n")
+		}
+	}
+
+	if len(summary.Services) > 0 {
+		builder.WriteString("## Services\n")
+		builder.WriteString("| Name | Type | Path | Provides |\n")
+		builder.WriteString("| --- | --- | --- | --- |\n")
+		for _, svc := range summary.Services {
+			builder.WriteString(fmt.Sprintf("| %s | %s | %s | %s |\n", svc.Name, svc.Type, svc.Path, strings.Join(svc.Provides, ", ")))
+		}
+		builder.WriteString("\n")
+	}
+
+	if len(summary.Secrets) > 0 {
+		builder.WriteString("## Secrets\n")
+		builder.WriteString("| File | Line | Rule | Match | Entropy |\n")
+		builder.WriteString("| --- | --- | --- | --- | --- |\n")
+		for _, sec := range summary.Secrets {
+			builder.WriteString(fmt.Sprintf("| %s | %d | %s | `%s` | %.2f |\n", sec.File, sec.Line, sec.Rule, sec.Match, sec.Entropy))
+		}
+		builder.WriteString("\n")
+	}
+
+	if len(summary.Binaries) > 0 {
+		builder.WriteString("## Binary Protections\n")
+		builder.WriteString(binaryinspector.CollectMarkdownTable(summary.Binaries))
+		builder.WriteString("\n")
+	}
+
+	if len(summary.Vulnerable) > 0 {
+		builder.WriteString("## Vulnerabilities\n")
+		builder.WriteString("| Path | Hash | CVEs | Error |\n")
+		builder.WriteString("| --- | --- | --- | --- |\n")
+		for _, vul := range summary.Vulnerable {
+			ids := "-"
+			if len(vul.CVEs) > 0 {
+				var parts []string
+				for _, c := range vul.CVEs {
+					if c.ID != "" {
+						parts = append(parts, c.ID)
+					}
+				}
+				if len(parts) > 0 {
+					ids = strings.Join(parts, ", ")
+				}
+			}
+			hash := vul.Hash
+			if hash == "" {
+				hash = "-"
+			}
+			errMsg := "-"
+			if vul.Error != "" {
+				errMsg = vul.Error
+			}
+			builder.WriteString(fmt.Sprintf("| %s | %s | %s | %s |\n", vul.Path, hash, ids, errMsg))
+		}
+		builder.WriteString("\n")
+	}
+
+        if summary.SBOM != nil {
+                builder.WriteString("## SBOM\n")
+                format := strings.ToUpper(string(summary.SBOM.Format))
+                builder.WriteString(fmt.Sprintf("Generated %s document with %d packages.\n\n", format, len(summary.SBOM.Packages)))
+                switch {
+                case len(summary.SBOMPaths) > 0:
+                        builder.WriteString("Files:\n")
+                        for _, p := range summary.SBOMPaths {
+                                builder.WriteString(fmt.Sprintf("- `%s`\n", p))
+                        }
+                        builder.WriteString("\n")
+                case summary.SBOMPath != "":
+                        builder.WriteString(fmt.Sprintf("File: `%s`\n\n", summary.SBOMPath))
+                }
+                if len(summary.SBOMSignatures) > 0 {
+                        builder.WriteString("Signatures:\n")
+                        for _, sig := range summary.SBOMSignatures {
+                                builder.WriteString(fmt.Sprintf("- `%s`\n", sig))
+                        }
+                        builder.WriteString("\n")
+                }
+        }
+
+	if len(summary.Plugins) > 0 {
+		builder.WriteString("## Plugin Findings\n")
+		for _, res := range summary.Plugins {
+			builder.WriteString(fmt.Sprintf("### %s\n", res.Plugin))
+			if res.Error != "" {
+				builder.WriteString(fmt.Sprintf("Error: %s\n\n", res.Error))
+				continue
+			}
+			if len(res.Findings) == 0 {
+				builder.WriteString("No findings reported.\n\n")
+				continue
+			}
+			builder.WriteString("| Summary | Severity | Details |\n")
+			builder.WriteString("| --- | --- | --- |\n")
+			for _, finding := range res.Findings {
+				severity := finding.Severity
+				if severity == "" {
+					severity = "info"
+				}
+				details := "-"
+				if len(finding.Details) > 0 {
+					keys := make([]string, 0, len(finding.Details))
+					for k := range finding.Details {
+						keys = append(keys, k)
+					}
+					sort.Strings(keys)
+					pairs := make([]string, 0, len(keys))
+					for _, k := range keys {
+						pairs = append(pairs, fmt.Sprintf("%s=%v", k, finding.Details[k]))
+					}
+					details = strings.Join(pairs, "; ")
+				}
+				builder.WriteString(fmt.Sprintf("| %s | %s | %s |\n", finding.Summary, severity, details))
+			}
+			builder.WriteString("\n")
+		}
+	}
+
+	return builder.String()
+}
+
+// HTML renders a minimal HTML document embedding the Markdown content.
+func (g *Generator) HTML(summary Summary) (string, error) {
+	return g.htmlFromMarkdown(g.Markdown(summary))
+}
+
+// Formats declares which report artefacts should be written.
+type Formats struct {
+	Markdown bool
+	HTML     bool
+	JSON     bool
+}
+
+// DefaultFormats enables all report formats.
+var DefaultFormats = Formats{Markdown: true, HTML: true, JSON: true}
+
+// Paths describes the artefacts written to disk.
+type Paths struct {
+	Markdown string
+	HTML     string
+	JSON     string
+}
+
+// WriteFiles writes selected report formats to the specified directory.
+func (g *Generator) WriteFiles(summary Summary, outputDir string, formats Formats) (Paths, error) {
+        if err := os.MkdirAll(outputDir, 0o755); err != nil {
+                return Paths{}, err
+        }
+	if !formats.Markdown && !formats.HTML && !formats.JSON {
+		formats = DefaultFormats
+	}
+	var paths Paths
+	var md string
+	if formats.Markdown || formats.HTML {
+		md = g.Markdown(summary)
+	}
+	if formats.Markdown {
+		mdPath := filepath.Join(outputDir, "report.md")
+		if err := os.WriteFile(mdPath, []byte(md), 0o644); err != nil {
+			return Paths{}, err
+		}
+		paths.Markdown = mdPath
+	}
+	if formats.HTML {
+		html, err := g.htmlFromMarkdown(md)
+		if err != nil {
+			return Paths{}, err
+		}
+		htmlPath := filepath.Join(outputDir, "report.html")
+		if err := os.WriteFile(htmlPath, []byte(html), 0o644); err != nil {
+			return Paths{}, err
+		}
+		paths.HTML = htmlPath
+	}
+	if formats.JSON {
+		data, err := json.MarshalIndent(summary, "", "  ")
+		if err != nil {
+			return Paths{}, err
+		}
+		jsonPath := filepath.Join(outputDir, "report.json")
+		if err := os.WriteFile(jsonPath, data, 0o644); err != nil {
+			return Paths{}, err
+		}
+		paths.JSON = jsonPath
+        }
+        return paths, nil
+}
+
+// LoadJSON reads a JSON summary generated by WriteFiles.
+func LoadJSON(path string) (Summary, error) {
+        data, err := os.ReadFile(path)
+        if err != nil {
+                return Summary{}, err
+        }
+        var summary Summary
+        if err := json.Unmarshal(data, &summary); err != nil {
+                return Summary{}, err
+        }
+        return summary, nil
+}
+
+func (g *Generator) htmlFromMarkdown(md string) (string, error) {
+	tmpl := `<html><head><meta charset="utf-8"><title>Drone Firmware Analyzer Report</title></head><body><pre>{{.}}</pre></body></html>`
+	t, err := template.New("report").Parse(tmpl)
+	if err != nil {
+		return "", err
+	}
+	var builder strings.Builder
+	if err := t.Execute(&builder, md); err != nil {
+		return "", err
+	}
+	return builder.String(), nil
+}

--- a/pkg/sbom/encode.go
+++ b/pkg/sbom/encode.go
@@ -1,0 +1,162 @@
+package sbom
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+var errUnknownFormat = errors.New("unknown sbom format")
+
+// Encode renders the supplied document using the requested format and returns
+// the serialised bytes together with a recommended file extension. The
+// extension does not include a leading dot.
+func Encode(doc Document, format Format) ([]byte, string, error) {
+	switch normaliseFormat(format) {
+	case FormatSPDX, FormatSPDXJSON:
+		copyDoc := doc
+		copyDoc.Format = FormatSPDXJSON
+		data, err := json.MarshalIndent(copyDoc, "", "  ")
+		if err != nil {
+			return nil, "", err
+		}
+		return data, "spdx.json", nil
+	case FormatSPDXTagValue:
+		copyDoc := doc
+		copyDoc.Format = FormatSPDXTagValue
+		return []byte(renderSPDXTagValue(copyDoc)), "spdx", nil
+	case FormatCycloneDX:
+		copyDoc := doc
+		copyDoc.Format = FormatCycloneDX
+		data, err := json.MarshalIndent(copyDoc, "", "  ")
+		if err != nil {
+			return nil, "", err
+		}
+		return data, "cdx.json", nil
+	default:
+		return nil, "", errUnknownFormat
+	}
+}
+
+func renderSPDXTagValue(doc Document) string {
+	var buf bytes.Buffer
+	buf.WriteString("SPDXVersion: SPDX-2.3\n")
+	buf.WriteString("DataLicense: CC0-1.0\n")
+	buf.WriteString(fmt.Sprintf("DocumentName: %s\n", escapeTagValue(doc.Name)))
+	buf.WriteString(fmt.Sprintf("SPDXID: SPDXRef-DOCUMENT\n"))
+	buf.WriteString(fmt.Sprintf("DocumentNamespace: https://firmwareanalyzer.local/spdx/%s\n", sanitizeNamespace(doc.Name)))
+	buf.WriteString("Creator: Tool: Drone Firmware Analyzer\n")
+	buf.WriteString(fmt.Sprintf("Created: %s\n", doc.Created.Format("2006-01-02T15:04:05Z")))
+	buf.WriteString("\n")
+
+	for i, pkg := range doc.Packages {
+		spdxID := fmt.Sprintf("SPDXRef-Package-%d", i+1)
+		buf.WriteString(fmt.Sprintf("PackageName: %s\n", escapeTagValue(pkg.Name)))
+		buf.WriteString(fmt.Sprintf("SPDXID: %s\n", spdxID))
+		if pkg.Version != "" {
+			buf.WriteString(fmt.Sprintf("PackageVersion: %s\n", escapeTagValue(pkg.Version)))
+		}
+		if pkg.Supplier != "" {
+			buf.WriteString(fmt.Sprintf("PackageSupplier: %s\n", escapeTagValue(pkg.Supplier)))
+		}
+		if pkg.Path != "" {
+			buf.WriteString(fmt.Sprintf("ExternalRef: OTHER location %s\n", escapeTagValue(pkg.Path)))
+		}
+		buf.WriteString("PackageDownloadLocation: NOASSERTION\n")
+		buf.WriteString("FilesAnalyzed: false\n")
+		buf.WriteString("PackageLicenseConcluded: NOASSERTION\n")
+		buf.WriteString("PackageLicenseDeclared: NOASSERTION\n")
+		buf.WriteString("PackageCopyrightText: NOASSERTION\n")
+		buf.WriteString("\n")
+	}
+
+	if len(doc.Partitions) > 0 {
+		buf.WriteString("# Partitions\n")
+		sort.Slice(doc.Partitions, func(i, j int) bool {
+			return doc.Partitions[i].Name < doc.Partitions[j].Name
+		})
+		for _, part := range doc.Partitions {
+			buf.WriteString(fmt.Sprintf("## %s\n", escapeTagValue(part.Name)))
+			buf.WriteString(fmt.Sprintf("Type: %s\n", escapeTagValue(part.Type)))
+			if part.Path != "" {
+				buf.WriteString(fmt.Sprintf("Path: %s\n", escapeTagValue(part.Path)))
+			}
+			if part.Size > 0 {
+				buf.WriteString(fmt.Sprintf("Size: %d\n", part.Size))
+			}
+			if part.Offset > 0 {
+				buf.WriteString(fmt.Sprintf("Offset: %d\n", part.Offset))
+			}
+			if part.Entropy > 0 {
+				buf.WriteString(fmt.Sprintf("Entropy: %.2f\n", part.Entropy))
+			}
+			if part.Compression != "" {
+				buf.WriteString(fmt.Sprintf("Compression: %s\n", escapeTagValue(part.Compression)))
+			}
+			if part.Notes != "" {
+				buf.WriteString(fmt.Sprintf("Notes: %s\n", escapeTagValue(part.Notes)))
+			}
+			buf.WriteString("\n")
+		}
+	}
+
+	return buf.String()
+}
+
+func escapeTagValue(value string) string {
+	value = strings.ReplaceAll(value, "\n", " ")
+	value = strings.ReplaceAll(value, "\r", " ")
+	return value
+}
+
+func sanitizeNamespace(name string) string {
+	cleaned := strings.ToLower(name)
+	cleaned = strings.ReplaceAll(cleaned, " ", "-")
+	cleaned = strings.ReplaceAll(cleaned, "_", "-")
+	cleaned = strings.Map(func(r rune) rune {
+		switch {
+		case r >= 'a' && r <= 'z':
+			return r
+		case r >= '0' && r <= '9':
+			return r
+		case r == '-':
+			return r
+		default:
+			return -1
+		}
+	}, cleaned)
+	if cleaned == "" {
+		cleaned = "document"
+	}
+	return cleaned
+}
+
+func normaliseFormat(format Format) Format {
+	switch format {
+	case FormatSPDX:
+		return FormatSPDXJSON
+	default:
+		return format
+	}
+}
+
+func writeFile(path string, data []byte) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0o644)
+}
+
+func writeSignature(path string, signature []byte) error {
+	if len(signature) == 0 {
+		return nil
+	}
+	encoded := base64.StdEncoding.EncodeToString(signature)
+	return writeFile(path, []byte(encoded))
+}

--- a/pkg/sbom/sbom.go
+++ b/pkg/sbom/sbom.go
@@ -1,0 +1,245 @@
+package sbom
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"firmwareanalyzer/pkg/binaryinspector"
+	"firmwareanalyzer/pkg/extractor"
+)
+
+// Format enumerates supported SBOM representations.
+type Format string
+
+const (
+	// FormatSPDX represents an SPDX JSON document. It is retained for
+	// backwards compatibility with earlier releases that only emitted JSON.
+	FormatSPDX Format = "spdx"
+	// FormatSPDXJSON explicitly selects the SPDX JSON representation.
+	FormatSPDXJSON Format = "spdx-json"
+	// FormatSPDXTagValue emits an SPDX 2.3 tag-value document.
+	FormatSPDXTagValue Format = "spdx-tag-value"
+	// FormatCycloneDX emits a simplified CycloneDX 1.5 JSON document.
+	FormatCycloneDX Format = "cyclonedx"
+)
+
+// Options control SBOM generation behaviour.
+type Options struct {
+	Formats        []Format
+	ProductName    string
+	SigningKeyPath string
+}
+
+// Package describes a software package present in the firmware image.
+type Package struct {
+	Name     string `json:"name"`
+	Version  string `json:"version,omitempty"`
+	Supplier string `json:"supplier,omitempty"`
+	Path     string `json:"path,omitempty"`
+}
+
+// Document is the format-agnostic SBOM representation used internally.
+type Document struct {
+	Format     Format                `json:"format"`
+	Created    time.Time             `json:"created"`
+	Name       string                `json:"name"`
+	Packages   []Package             `json:"packages"`
+	Partitions []extractor.Partition `json:"partitions,omitempty"`
+}
+
+// Generator produces SBOM documents for extracted firmware trees.
+type Generator struct {
+	logger *log.Logger
+	opts   Options
+	signer signer
+}
+
+// NewGenerator constructs a Generator, discarding log output when logger is nil.
+func NewGenerator(logger *log.Logger, opts Options) (*Generator, error) {
+	if logger == nil {
+		logger = log.New(io.Discard, "sbom", log.LstdFlags)
+	}
+	if len(opts.Formats) == 0 {
+		opts.Formats = []Format{FormatSPDX}
+	}
+	if opts.SigningKeyPath != "" {
+		signer, err := newEd25519Signer(opts.SigningKeyPath)
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				logger.Printf("sbom signing disabled: %v", err)
+			} else {
+				return nil, err
+			}
+		} else {
+			return &Generator{logger: logger, opts: opts, signer: signer}, nil
+		}
+	}
+	return &Generator{logger: logger, opts: opts}, nil
+}
+
+// Generate inspects the extraction root and produces an SBOM document. Package
+// information is sourced from package manager metadata when available and
+// otherwise falls back to binaries discovered during inspection. Partition
+// metadata is included to provide additional context for downstream tooling.
+func (g *Generator) Generate(ctx context.Context, root string, binaries []binaryinspector.Result, partitions []extractor.Partition) (Document, error) {
+	packages, err := g.detectPackages(ctx, root)
+	if err != nil {
+		return Document{}, err
+	}
+	if len(packages) == 0 {
+		fallback := fallbackPackages(binaries)
+		packages = append(packages, fallback...)
+	}
+	sort.Slice(packages, func(i, j int) bool {
+		if packages[i].Name == packages[j].Name {
+			return packages[i].Version < packages[j].Version
+		}
+		return packages[i].Name < packages[j].Name
+	})
+	name := g.opts.ProductName
+	if name == "" {
+		name = filepath.Base(root)
+	}
+	return Document{
+		Format:     g.primaryFormat(),
+		Created:    time.Now().UTC(),
+		Name:       name,
+		Packages:   packages,
+		Partitions: partitions,
+	}, nil
+}
+
+// WriteJSON serialises the SBOM document to the provided path using the SPDX
+// JSON format. It is retained for backwards compatibility with earlier
+// versions.
+func WriteJSON(doc Document, path string) error {
+	data, _, err := Encode(doc, FormatSPDXJSON)
+	if err != nil {
+		return err
+	}
+	return writeFile(path, data)
+}
+
+// Signer returns true when SBOM signing is enabled.
+func (g *Generator) Signer() bool {
+	return g.signer != nil
+}
+
+// Sign produces a detached signature for the supplied data when signing is
+// configured. When signing is disabled Sign returns nil without error.
+func (g *Generator) Sign(data []byte) ([]byte, error) {
+	if g.signer == nil {
+		return nil, nil
+	}
+	return g.signer.Sign(data)
+}
+
+func (g *Generator) primaryFormat() Format {
+	if len(g.opts.Formats) == 0 {
+		return FormatSPDX
+	}
+	if g.opts.Formats[0] == FormatSPDX {
+		return FormatSPDXJSON
+	}
+	return g.opts.Formats[0]
+}
+
+// Formats returns the configured output formats.
+func (g *Generator) Formats() []Format {
+	formats := make([]Format, len(g.opts.Formats))
+	copy(formats, g.opts.Formats)
+	return formats
+}
+
+func (g *Generator) detectPackages(ctx context.Context, root string) ([]Package, error) {
+	opkgDir := filepath.Join(root, "usr", "lib", "opkg", "info")
+	entries, err := os.ReadDir(opkgDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read opkg info: %w", err)
+	}
+	var packages []Package
+	for _, entry := range entries {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		default:
+		}
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".control") {
+			continue
+		}
+		controlPath := filepath.Join(opkgDir, entry.Name())
+		pkg, err := parseControlFile(controlPath)
+		if err != nil {
+			g.logger.Printf("skip %s: %v", controlPath, err)
+			continue
+		}
+		packages = append(packages, pkg)
+	}
+	return packages, nil
+}
+
+func parseControlFile(path string) (Package, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return Package{}, err
+	}
+	lines := strings.Split(string(data), "\n")
+	pkg := Package{Path: filepath.Dir(path)}
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		parts := strings.SplitN(line, ":", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		key := strings.ToLower(strings.TrimSpace(parts[0]))
+		value := strings.TrimSpace(parts[1])
+		switch key {
+		case "package":
+			pkg.Name = value
+		case "version":
+			pkg.Version = value
+		case "maintainer":
+			pkg.Supplier = value
+		}
+	}
+	if pkg.Name == "" {
+		return Package{}, fmt.Errorf("missing package name")
+	}
+	return pkg, nil
+}
+
+func fallbackPackages(binaries []binaryinspector.Result) []Package {
+	seen := make(map[string]Package)
+	for _, bin := range binaries {
+		if bin.Path == "" || bin.Err != "" {
+			continue
+		}
+		name := filepath.Base(bin.Path)
+		if name == "" {
+			continue
+		}
+		if _, exists := seen[name]; exists {
+			continue
+		}
+		seen[name] = Package{Name: name, Path: bin.Path}
+	}
+	out := make([]Package, 0, len(seen))
+	for _, pkg := range seen {
+		out = append(out, pkg)
+	}
+	return out
+}

--- a/pkg/sbom/sign.go
+++ b/pkg/sbom/sign.go
@@ -1,0 +1,64 @@
+package sbom
+
+import (
+	"crypto/ed25519"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"os"
+)
+
+type signer interface {
+	Sign(data []byte) ([]byte, error)
+}
+
+type ed25519Signer struct {
+	key ed25519.PrivateKey
+}
+
+func newEd25519Signer(path string) (signer, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read signing key: %w", err)
+	}
+
+	block, _ := pem.Decode(data)
+	if block == nil {
+		return nil, fmt.Errorf("invalid PEM data in %s", path)
+	}
+
+	switch block.Type {
+	case "ED25519 PRIVATE KEY":
+		key, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+		if err == nil {
+			if pk, ok := key.(ed25519.PrivateKey); ok {
+				return &ed25519Signer{key: pk}, nil
+			}
+		}
+		keyBytes := block.Bytes
+		if len(keyBytes) == ed25519.PrivateKeySize {
+			return &ed25519Signer{key: ed25519.PrivateKey(keyBytes)}, nil
+		}
+		return nil, fmt.Errorf("unsupported ed25519 key format")
+	case "PRIVATE KEY":
+		key, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+		if err != nil {
+			return nil, fmt.Errorf("parse private key: %w", err)
+		}
+		pk, ok := key.(ed25519.PrivateKey)
+		if !ok {
+			return nil, fmt.Errorf("private key is not ed25519")
+		}
+		return &ed25519Signer{key: pk}, nil
+	default:
+		return nil, fmt.Errorf("unsupported key type %q", block.Type)
+	}
+}
+
+func (s *ed25519Signer) Sign(data []byte) ([]byte, error) {
+	if len(s.key) != ed25519.PrivateKeySize {
+		return nil, fmt.Errorf("invalid ed25519 private key length")
+	}
+	sig := ed25519.Sign(s.key, data)
+	return sig, nil
+}

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -1,0 +1,277 @@
+package scheduler
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// Options configures the scheduler behaviour.
+type Options struct {
+	AnalyzerPath   string
+	Concurrency    int
+	Logger         *log.Logger
+	LocalExecutor  Executor
+	RemoteExecutor Executor
+	RemoteHosts    map[string]RemoteHost
+}
+
+// RemoteHost describes an execution target that runs analyses over SSH.
+type RemoteHost struct {
+	Name         string
+	Address      string
+	User         string
+	AnalyzerPath string
+	SSHBinary    string
+}
+
+// Job represents a firmware analysis to run.
+type Job struct {
+	ID             string   `json:"id"`
+	Firmware       string   `json:"firmware"`
+	OutputDir      string   `json:"output_dir"`
+	HistoryDir     string   `json:"history_dir,omitempty"`
+	ReportFormats  []string `json:"report_formats,omitempty"`
+	BaselineReport string   `json:"baseline_report,omitempty"`
+	DiffFormats    []string `json:"diff_formats,omitempty"`
+	ExtraArgs      []string `json:"extra_args,omitempty"`
+	RemoteHost     string   `json:"remote_host,omitempty"`
+	TimeoutSeconds int      `json:"timeout_seconds,omitempty"`
+}
+
+// Result captures the outcome of a scheduled job.
+type Result struct {
+	JobID      string    `json:"job_id"`
+	Firmware   string    `json:"firmware"`
+	OutputDir  string    `json:"output_dir"`
+	RemoteHost string    `json:"remote_host,omitempty"`
+	Started    time.Time `json:"started"`
+	Completed  time.Time `json:"completed"`
+	Command    []string  `json:"command"`
+	Error      string    `json:"error,omitempty"`
+}
+
+// Executor runs a command for local or remote execution targets.
+type Executor interface {
+	Run(ctx context.Context, name string, args ...string) error
+}
+
+// ExecFunc adapts a function to the Executor interface.
+type ExecFunc func(ctx context.Context, name string, args ...string) error
+
+// Run executes the command using the underlying function.
+func (f ExecFunc) Run(ctx context.Context, name string, args ...string) error {
+	return f(ctx, name, args...)
+}
+
+// Scheduler orchestrates batched firmware analyses across workers.
+type Scheduler struct {
+	opts      Options
+	logger    *log.Logger
+	jobs      chan Job
+	results   chan Result
+	wg        sync.WaitGroup
+	started   bool
+	startMu   sync.Mutex
+	closeOnce sync.Once
+	counter   uint64
+}
+
+// New constructs a Scheduler with sensible defaults.
+func New(opts Options) *Scheduler {
+	if opts.Concurrency <= 0 {
+		opts.Concurrency = 1
+	}
+	if opts.AnalyzerPath == "" {
+		opts.AnalyzerPath = "analyzer"
+	}
+	if opts.Logger == nil {
+		opts.Logger = log.New(io.Discard, "scheduler", log.LstdFlags)
+	}
+	if opts.LocalExecutor == nil {
+		opts.LocalExecutor = defaultExecutor(opts.Logger)
+	}
+	if opts.RemoteExecutor == nil {
+		opts.RemoteExecutor = opts.LocalExecutor
+	}
+	if opts.RemoteHosts == nil {
+		opts.RemoteHosts = make(map[string]RemoteHost)
+	}
+	return &Scheduler{opts: opts, logger: opts.Logger, jobs: make(chan Job)}
+}
+
+// Start launches the worker pool and returns a channel streaming job results.
+func (s *Scheduler) Start(ctx context.Context) <-chan Result {
+	s.startMu.Lock()
+	defer s.startMu.Unlock()
+	if s.started {
+		return s.results
+	}
+	s.started = true
+	s.results = make(chan Result)
+	for i := 0; i < s.opts.Concurrency; i++ {
+		s.wg.Add(1)
+		go s.worker(ctx)
+	}
+	return s.results
+}
+
+// Enqueue schedules a job for execution.
+func (s *Scheduler) Enqueue(job Job) error {
+	if job.Firmware == "" {
+		return fmt.Errorf("job missing firmware path")
+	}
+	if !s.started {
+		return errors.New("scheduler not started")
+	}
+	if job.ID == "" {
+		job.ID = s.nextID()
+	}
+	s.jobs <- job
+	return nil
+}
+
+// Close waits for workers to finish and closes the result channel.
+func (s *Scheduler) Close() {
+	s.closeOnce.Do(func() {
+		close(s.jobs)
+		s.wg.Wait()
+		close(s.results)
+	})
+}
+
+func (s *Scheduler) worker(ctx context.Context) {
+	defer s.wg.Done()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case job, ok := <-s.jobs:
+			if !ok {
+				return
+			}
+			result := s.runJob(ctx, job)
+			select {
+			case <-ctx.Done():
+				return
+			case s.results <- result:
+			}
+		}
+	}
+}
+
+func (s *Scheduler) runJob(ctx context.Context, job Job) Result {
+	start := time.Now().UTC()
+	args := s.buildArgs(job)
+	result := Result{
+		JobID:      job.ID,
+		Firmware:   job.Firmware,
+		OutputDir:  job.OutputDir,
+		RemoteHost: job.RemoteHost,
+		Started:    start,
+		Command:    args,
+	}
+	execCtx := ctx
+	cancel := func() {}
+	if job.TimeoutSeconds > 0 {
+		execCtx, cancel = context.WithTimeout(ctx, time.Duration(job.TimeoutSeconds)*time.Second)
+	}
+	defer cancel()
+
+	var err error
+	if job.RemoteHost == "" {
+		err = s.opts.LocalExecutor.Run(execCtx, s.opts.AnalyzerPath, args...)
+		result.Command = append([]string{s.opts.AnalyzerPath}, args...)
+	} else {
+		host, ok := s.opts.RemoteHosts[job.RemoteHost]
+		if !ok {
+			err = fmt.Errorf("unknown remote host %q", job.RemoteHost)
+		} else {
+			target := host.Address
+			if host.User != "" {
+				target = host.User + "@" + host.Address
+			}
+			sshBin := host.SSHBinary
+			if sshBin == "" {
+				sshBin = "ssh"
+			}
+			remoteAnalyzer := host.AnalyzerPath
+			if remoteAnalyzer == "" {
+				remoteAnalyzer = s.opts.AnalyzerPath
+			}
+			cmdArgs := append([]string{target, remoteAnalyzer}, args...)
+			result.Command = append([]string{sshBin}, cmdArgs...)
+			err = s.opts.RemoteExecutor.Run(execCtx, sshBin, cmdArgs...)
+		}
+	}
+	result.Completed = time.Now().UTC()
+	if err != nil {
+		result.Error = err.Error()
+	}
+	return result
+}
+
+func (s *Scheduler) buildArgs(job Job) []string {
+	var args []string
+	args = append(args, "--fw", job.Firmware)
+	if job.OutputDir != "" {
+		args = append(args, "--out", job.OutputDir)
+	}
+	if job.HistoryDir != "" {
+		args = append(args, "--history-dir", job.HistoryDir)
+	}
+	if len(job.ReportFormats) > 0 {
+		args = append(args, "--report-formats", strings.Join(job.ReportFormats, ","))
+	}
+	if job.BaselineReport != "" {
+		args = append(args, "--baseline-report", job.BaselineReport)
+	}
+	if len(job.DiffFormats) > 0 {
+		args = append(args, "--diff-formats", strings.Join(job.DiffFormats, ","))
+	}
+	if len(job.ExtraArgs) > 0 {
+		args = append(args, job.ExtraArgs...)
+	}
+	return args
+}
+
+func (s *Scheduler) nextID() string {
+	id := atomic.AddUint64(&s.counter, 1)
+	return fmt.Sprintf("job-%d", id)
+}
+
+func defaultExecutor(logger *log.Logger) Executor {
+	return ExecFunc(func(ctx context.Context, name string, args ...string) error {
+		cmd := exec.CommandContext(ctx, name, args...)
+		if logger != nil {
+			writer := logger.Writer()
+			if closer, ok := writer.(io.Closer); ok {
+				defer closer.Close()
+			}
+			cmd.Stdout = writer
+			cmd.Stderr = writer
+		}
+		return cmd.Run()
+	})
+}
+
+// ResolveReportDir determines the path used for report outputs when a job completes.
+func ResolveReportDir(paths []string) string {
+	for _, path := range paths {
+		if path == "" {
+			continue
+		}
+		if filepath.Ext(path) != "" {
+			return filepath.Dir(path)
+		}
+	}
+	return ""
+}

--- a/pkg/secrets/secrets.go
+++ b/pkg/secrets/secrets.go
@@ -1,0 +1,203 @@
+package secrets
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+
+	"firmwareanalyzer/pkg/utils"
+)
+
+// Finding represents a potential secret discovered within a file.
+type Finding struct {
+	File    string  `json:"file"`
+	Line    int     `json:"line"`
+	Match   string  `json:"match"`
+	Rule    string  `json:"rule"`
+	Entropy float64 `json:"entropy"`
+}
+
+// Scanner searches firmware trees for credentials using regex and entropy
+// heuristics. An allow-list can be provided to reduce false positives.
+type Scanner struct {
+	logger      *log.Logger
+	allowExact  map[string]struct{}
+	allowRules  map[string][]string
+	patterns    []pattern
+	minEntropy  float64
+	maxFileSize int64
+}
+
+type pattern struct {
+	name       string
+	re         *regexp.Regexp
+	minEntropy float64
+	minLength  int
+}
+
+// ScannerOptions customise the behaviour of the secret scanner.
+type ScannerOptions struct {
+	AllowExact        []string
+	AllowRulePatterns map[string][]string
+	MinEntropy        float64
+	MaxFileSize       int64
+}
+
+// NewScanner creates a scanner configured with sensible defaults.
+func NewScanner(logger *log.Logger, allowList []string) *Scanner {
+	return NewScannerWithOptions(logger, ScannerOptions{AllowExact: allowList})
+}
+
+// NewScannerWithOptions builds a scanner using custom thresholds and allow-lists.
+func NewScannerWithOptions(logger *log.Logger, opts ScannerOptions) *Scanner {
+	if logger == nil {
+		logger = log.New(io.Discard, "secrets", log.LstdFlags)
+	}
+	allowExact := make(map[string]struct{}, len(opts.AllowExact))
+	for _, item := range opts.AllowExact {
+		allowExact[item] = struct{}{}
+	}
+	patterns := []pattern{
+		{name: "AWS Access Key", re: regexp.MustCompile(`AKIA[0-9A-Z]{16}`)},
+		{name: "Generic API Key", re: regexp.MustCompile(`[A-Za-z0-9_\-]{24,}`), minEntropy: 3.5, minLength: 24},
+		{name: "JWT", re: regexp.MustCompile(`eyJ[\w-]{20,}\.[\w-]{20,}\.[\w-]{10,}`), minEntropy: 3.0},
+		{name: "Slack Token", re: regexp.MustCompile(`xox[baprs]-[A-Za-z0-9-]{10,}`), minEntropy: 3.0},
+		{name: "Private Key", re: regexp.MustCompile(`-----BEGIN [A-Z ]+PRIVATE KEY-----`), minEntropy: 0, minLength: 0},
+		{name: "SSH Authorized Key", re: regexp.MustCompile(`ssh-(rsa|ed25519|dss) [A-Za-z0-9+/=]+`), minEntropy: 2.5},
+		{name: "Password Assignment", re: regexp.MustCompile(`(?i)(password|passwd|secret)\s*=\s*['\"]?([^'\"\s]+)`), minEntropy: 0},
+	}
+	minEntropy := opts.MinEntropy
+	if minEntropy == 0 {
+		minEntropy = 3.5
+	}
+	maxFile := opts.MaxFileSize
+	if maxFile == 0 {
+		maxFile = 1 << 20
+	}
+	return &Scanner{
+		logger:      logger,
+		allowExact:  allowExact,
+		allowRules:  opts.AllowRulePatterns,
+		patterns:    patterns,
+		minEntropy:  minEntropy,
+		maxFileSize: maxFile,
+	}
+}
+
+// Scan walks the root directory, scanning text files and reporting any
+// discoveries that meet entropy requirements and are not allow-listed.
+func (s *Scanner) Scan(ctx context.Context, root string) ([]Finding, error) {
+	var findings []Finding
+	err := filepath.WalkDir(root, func(path string, d os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.IsDir() {
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+		info, err := d.Info()
+		if err != nil {
+			return err
+		}
+		if info.Size() > s.maxFileSize {
+			return nil
+		}
+		fileFindings, err := s.scanFile(path)
+		if err != nil {
+			return err
+		}
+		findings = append(findings, fileFindings...)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	sort.Slice(findings, func(i, j int) bool {
+		if findings[i].File == findings[j].File {
+			return findings[i].Line < findings[j].Line
+		}
+		return findings[i].File < findings[j].File
+	})
+	return findings, nil
+}
+
+func (s *Scanner) scanFile(path string) ([]Finding, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read file: %w", err)
+	}
+	if !utils.LooksLikeText(data) {
+		return nil, nil
+	}
+
+	var findings []Finding
+	lines := bytes.Split(data, []byte{'\n'})
+	for i, rawLine := range lines {
+		lineNum := i + 1
+		line := strings.TrimRight(string(rawLine), "\r")
+		for _, pat := range s.patterns {
+			matches := pat.re.FindAllStringSubmatch(line, -1)
+			if len(matches) == 0 {
+				continue
+			}
+			for _, match := range matches {
+				candidate := match[0]
+				if _, ok := s.allowExact[candidate]; ok {
+					continue
+				}
+				if s.isRuleSuppressed(pat.name, candidate) {
+					continue
+				}
+				entropy := utils.ShannonEntropy(candidate)
+				threshold := s.minEntropy
+				if pat.minEntropy > 0 {
+					threshold = pat.minEntropy
+				}
+				if pat.minLength > 0 && len(candidate) < pat.minLength {
+					continue
+				}
+				if utils.ContainsCredentialKeyword(line) || entropy >= threshold {
+					findings = append(findings, Finding{
+						File:    path,
+						Line:    lineNum,
+						Match:   candidate,
+						Rule:    pat.name,
+						Entropy: entropy,
+					})
+				}
+			}
+		}
+	}
+	return findings, nil
+}
+
+func (s *Scanner) isRuleSuppressed(rule, candidate string) bool {
+	if len(s.allowRules) == 0 {
+		return false
+	}
+	patterns, ok := s.allowRules[rule]
+	if !ok {
+		return false
+	}
+	for _, pattern := range patterns {
+		if ok, _ := filepath.Match(pattern, candidate); ok {
+			return true
+		}
+		if strings.HasPrefix(candidate, pattern) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -1,0 +1,172 @@
+package service
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// Service represents an init component discovered inside a firmware image.
+type Service struct {
+	Name     string   `json:"name"`
+	Path     string   `json:"path"`
+	Type     string   `json:"type"`
+	Provides []string `json:"provides,omitempty"`
+}
+
+// Detector scans extracted filesystem trees for init systems, rc scripts and
+// unit definitions to help build a runtime service inventory.
+type Detector struct {
+	logger *log.Logger
+}
+
+// NewDetector constructs a Detector. When logger is nil, logging is discarded.
+func NewDetector(logger *log.Logger) *Detector {
+	if logger == nil {
+		logger = log.New(io.Discard, "service", log.LstdFlags)
+	}
+	return &Detector{logger: logger}
+}
+
+// Detect searches for SysV init scripts (etc/init.d), BusyBox rc directories,
+// and systemd unit files within the provided root.
+func (d *Detector) Detect(ctx context.Context, root string) ([]Service, error) {
+	var services []Service
+
+	visit := func(dir string, handler func(string, os.DirEntry) error) error {
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			if os.IsNotExist(err) {
+				return nil
+			}
+			return err
+		}
+		for _, entry := range entries {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			default:
+			}
+			if err := handler(filepath.Join(dir, entry.Name()), entry); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
+	sysvDirs := []string{
+		filepath.Join(root, "etc", "init.d"),
+		filepath.Join(root, "etc", "rc.d"),
+	}
+	for _, dir := range sysvDirs {
+		err := visit(dir, func(path string, entry os.DirEntry) error {
+			if entry.IsDir() {
+				return nil
+			}
+			info, err := entry.Info()
+			if err != nil {
+				return err
+			}
+			if info.Mode()&0o111 == 0 {
+				return nil
+			}
+			services = append(services, Service{
+				Name: entry.Name(),
+				Path: path,
+				Type: "sysvinit",
+			})
+			return nil
+		})
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	rcDirs := []string{
+		filepath.Join(root, "etc", "rc.d"),
+		filepath.Join(root, "etc", "init.d"),
+	}
+	for _, dir := range rcDirs {
+		err := visit(dir, func(path string, entry os.DirEntry) error {
+			if entry.IsDir() || strings.HasPrefix(entry.Name(), ".") {
+				return nil
+			}
+			if strings.HasPrefix(entry.Name(), "S") || strings.HasPrefix(entry.Name(), "K") {
+				services = append(services, Service{
+					Name: entry.Name(),
+					Path: path,
+					Type: "busybox-rc",
+				})
+			}
+			return nil
+		})
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	unitDirs := []string{
+		filepath.Join(root, "lib", "systemd", "system"),
+		filepath.Join(root, "etc", "systemd", "system"),
+	}
+	for _, dir := range unitDirs {
+		err := visit(dir, func(path string, entry os.DirEntry) error {
+			if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".service") {
+				return nil
+			}
+			provides, err := parseProvides(path)
+			if err != nil {
+				return err
+			}
+			services = append(services, Service{
+				Name:     strings.TrimSuffix(entry.Name(), ".service"),
+				Path:     path,
+				Type:     "systemd",
+				Provides: provides,
+			})
+			return nil
+		})
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return services, nil
+}
+
+func parseProvides(path string) ([]string, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("open unit: %w", err)
+	}
+	defer file.Close()
+
+	var provides []string
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if strings.HasPrefix(line, "#") || line == "" {
+			continue
+		}
+		lower := strings.ToLower(line)
+		if strings.HasPrefix(lower, "provides=") {
+			parts := strings.SplitN(line, "=", 2)
+			if len(parts) != 2 {
+				continue
+			}
+			value := strings.Trim(parts[1], "\"'")
+			provides = append(provides, strings.FieldsFunc(value, func(r rune) bool {
+				return r == ' ' || r == ','
+			})...)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	return provides, nil
+}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -1,0 +1,203 @@
+package utils
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"math"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+	"unicode/utf8"
+)
+
+// Flatten walks arbitrarily nested data structures (maps, slices, arrays)
+// and returns a map keyed by dot-separated paths with stringified values.
+// It is primarily used by the configuration parser to expose nested settings
+// in a uniform representation for downstream modules.
+func Flatten(prefix string, value any) map[string]string {
+	out := make(map[string]string)
+	flattenInto(out, prefix, value)
+	return out
+}
+
+func flattenInto(out map[string]string, prefix string, value any) {
+	switch v := value.(type) {
+	case map[string]interface{}:
+		keys := make([]string, 0, len(v))
+		for k := range v {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			next := k
+			if prefix != "" {
+				next = prefix + "." + k
+			}
+			flattenInto(out, next, v[k])
+		}
+	case []interface{}:
+		for idx, item := range v {
+			next := prefix + "[" + strconv.Itoa(idx) + "]"
+			flattenInto(out, next, item)
+		}
+	case json.Number:
+		out[prefix] = v.String()
+	case string:
+		out[prefix] = v
+	case fmt.Stringer:
+		out[prefix] = v.String()
+	case nil:
+		out[prefix] = ""
+	default:
+		out[prefix] = fmt.Sprint(v)
+	}
+}
+
+// ContainsCredentialKeyword reports whether the provided key path appears to
+// reference a credential. This is a heuristic used by both the configuration
+// parser and secret scanner to prioritise findings.
+func ContainsCredentialKeyword(key string) bool {
+	lowered := strings.ToLower(key)
+	keywords := []string{"pass", "secret", "token", "key", "auth", "cred"}
+	for _, kw := range keywords {
+		if strings.Contains(lowered, kw) {
+			return true
+		}
+	}
+	return false
+}
+
+// ShannonEntropy computes the Shannon entropy in bits of the supplied text.
+// High entropy strings are likely to be randomly generated secrets such as
+// API tokens. The function operates on runes to better support UTF-8 input.
+func ShannonEntropy(text string) float64 {
+	if text == "" {
+		return 0
+	}
+	freq := make(map[rune]int)
+	total := 0
+	for _, r := range text {
+		freq[r]++
+		total++
+	}
+	entropy := 0.0
+	for _, count := range freq {
+		p := float64(count) / float64(total)
+		entropy -= p * math.Log2(p)
+	}
+	return entropy
+}
+
+// ByteEntropy calculates the Shannon entropy of raw byte data. It is useful
+// for determining whether files are compressed or encrypted where text-based
+// heuristics are ineffective.
+func ByteEntropy(data []byte) float64 {
+	if len(data) == 0 {
+		return 0
+	}
+	var freq [256]int
+	for _, b := range data {
+		freq[int(b)]++
+	}
+	entropy := 0.0
+	total := float64(len(data))
+	for _, count := range freq {
+		if count == 0 {
+			continue
+		}
+		p := float64(count) / total
+		entropy -= p * math.Log2(p)
+	}
+	return entropy
+}
+
+// SampleFileEntropy reads up to limit bytes from the supplied path and returns
+// the Shannon entropy of the collected data. A zero or negative limit defaults
+// to sampling the first 512KiB. The function is designed for large firmware
+// artefacts where full-file processing would be unnecessarily expensive.
+func SampleFileEntropy(path string, limit int64) (float64, error) {
+	if limit <= 0 {
+		limit = 512 << 10
+	}
+	file, err := os.Open(path)
+	if err != nil {
+		return 0, fmt.Errorf("open file: %w", err)
+	}
+	defer file.Close()
+
+	buf := make([]byte, limit)
+	n, err := io.ReadFull(file, buf)
+	if err != nil {
+		if errors.Is(err, io.ErrUnexpectedEOF) || errors.Is(err, io.EOF) {
+			// Partial reads are expected for files smaller than the
+			// requested sample size.
+			if n == 0 {
+				return 0, nil
+			}
+			buf = buf[:n]
+		} else {
+			return 0, fmt.Errorf("read file: %w", err)
+		}
+	} else {
+		buf = buf[:n]
+	}
+	return ByteEntropy(buf), nil
+}
+
+// LooksLikeText checks whether a byte slice appears to be text by verifying
+// it does not contain excessive NUL bytes and that it is valid UTF-8.
+func LooksLikeText(data []byte) bool {
+	if len(data) == 0 {
+		return true
+	}
+	const maxNullRatio = 0.2
+	nulls := 0
+	for _, b := range data {
+		if b == 0 {
+			nulls++
+		}
+	}
+	if float64(nulls)/float64(len(data)) > maxNullRatio {
+		return false
+	}
+	return utf8.Valid(data)
+}
+
+// LooksLikeRoot inspects the immediate children of a directory to determine
+// whether it resembles a mounted root filesystem. It looks for common
+// top-level directories (etc, bin, sbin, usr) and returns true when at least
+// two markers are present.
+func LooksLikeRoot(path string) bool {
+	entries, err := os.ReadDir(path)
+	if err != nil {
+		return false
+	}
+	markers := map[string]struct{}{
+		"etc":  {},
+		"bin":  {},
+		"sbin": {},
+		"usr":  {},
+		"root": {},
+	}
+	matches := 0
+	for i, entry := range entries {
+		if i >= 64 {
+			break
+		}
+		name := strings.ToLower(entry.Name())
+		if entry.IsDir() {
+			if _, ok := markers[name]; ok {
+				matches++
+			}
+		} else if strings.HasSuffix(name, "fstab") {
+			matches++
+		}
+		if matches >= 2 {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/vuln/data/curated.json
+++ b/pkg/vuln/data/curated.json
@@ -1,0 +1,43 @@
+{
+  "generated": "2024-05-30T00:00:00Z",
+  "sources": [
+    "Firmware Analyzer curated baseline"
+  ],
+  "artifacts": [
+    {
+      "sha256": "c3bf47ea1f4a4a605470313cacb3a44f4a461f68c6faeab07e737610cb5ac835",
+      "cves": [
+        {
+          "id": "CVE-2024-0001",
+          "severity": "high",
+          "description": "Sample vulnerability affecting legacy BusyBox telnetd builds shipped with drone firmware images.",
+          "references": [
+            "https://example.com/cves/CVE-2024-0001"
+          ]
+        }
+      ]
+    },
+    {
+      "sha256": "de4f03b7c2a7f1f77bfabf9ccb6f096d34f66bb594d27ad4ffdd43bccd4c6bd0",
+      "cves": [
+        {
+          "id": "CVE-2023-3157",
+          "severity": "critical",
+          "description": "Illustrative RCE in proprietary drone control daemons observed in reference samples.",
+          "references": [
+            "https://example.com/cves/CVE-2023-3157",
+            "https://nvd.nist.gov/vuln/detail/CVE-2023-3157"
+          ]
+        },
+        {
+          "id": "CVE-2020-10135",
+          "severity": "medium",
+          "description": "Bluetooth KNOB attack impacting embedded stacks reused across UAVs.",
+          "references": [
+            "https://nvd.nist.gov/vuln/detail/CVE-2020-10135"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/vuln/embedded.go
+++ b/pkg/vuln/embedded.go
@@ -1,0 +1,9 @@
+package vuln
+
+import _ "embed"
+
+// embeddedCuratedDatabase contains the curated vulnerability database bundled
+// with releases. The file is generated via cmd/vulndbupdate.
+//
+//go:embed data/curated.json
+var embeddedCuratedDatabase []byte

--- a/pkg/vuln/vuln.go
+++ b/pkg/vuln/vuln.go
@@ -1,0 +1,718 @@
+package vuln
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"firmwareanalyzer/pkg/binaryinspector"
+)
+
+// CVE represents a single vulnerability entry associated with a binary hash.
+type CVE struct {
+	ID          string   `json:"id"`
+	Severity    string   `json:"severity,omitempty"`
+	Description string   `json:"description,omitempty"`
+	References  []string `json:"references,omitempty"`
+}
+
+type httpDoer interface {
+	Do(*http.Request) (*http.Response, error)
+}
+
+// OnlineOptions describe an external vulnerability provider.
+type OnlineOptions struct {
+	Enabled  bool
+	Endpoint string
+	APIKey   string
+}
+
+type cacheEntry struct {
+	CVEs []CVE `json:"cves"`
+}
+
+// Finding links a binary to zero or more CVEs discovered during enrichment.
+type Finding struct {
+	Path  string `json:"path"`
+	Hash  string `json:"hash"`
+	CVEs  []CVE  `json:"cves,omitempty"`
+	Error string `json:"error,omitempty"`
+}
+
+// Options configure the enrichment behaviour.
+type Options struct {
+	// DatabasePaths points to JSON files containing hash -> CVE mappings.
+	DatabasePaths []string
+	// DisableEmbedded prevents use of the curated database bundled with the
+	// binary via go:embed. The embedded database is enabled by default.
+	DisableEmbedded bool
+	// CacheDir stores online lookup results on disk when provided.
+	CacheDir string
+	// RateLimitPerMinute bounds external API requests. Values <= 0 disable
+	// rate limiting.
+	RateLimitPerMinute int
+	// HTTPClient allows tests to provide a custom client.
+	HTTPClient httpDoer
+	// OSV configures optional OSV lookups.
+	OSV OnlineOptions
+	// NVD configures optional NVD lookups.
+	NVD OnlineOptions
+}
+
+// Enricher augments binary inspection results with CVE metadata sourced from
+// offline databases. Databases are expected to be JSON documents mapping
+// hexadecimal SHA-256 digests to arrays of CVE descriptors.
+type Enricher struct {
+	logger       *log.Logger
+	opts         Options
+	client       httpDoer
+	cache        map[string]cacheEntry
+	cacheDir     string
+	rateInterval time.Duration
+	lastRequest  time.Time
+	disableOSV   bool
+	disableNVD   bool
+}
+
+// NewEnricher builds an Enricher. When logger is nil log output is discarded.
+func NewEnricher(logger *log.Logger, opts Options) *Enricher {
+	if logger == nil {
+		logger = log.New(io.Discard, "vuln", log.LstdFlags)
+	}
+	e := &Enricher{logger: logger, opts: opts, cache: make(map[string]cacheEntry)}
+	if opts.HTTPClient != nil {
+		e.client = opts.HTTPClient
+	} else {
+		e.client = http.DefaultClient
+	}
+	e.cacheDir = strings.TrimSpace(opts.CacheDir)
+	if opts.RateLimitPerMinute > 0 {
+		interval := time.Minute / time.Duration(opts.RateLimitPerMinute)
+		if interval > 0 {
+			e.rateInterval = interval
+		}
+	}
+	if e.opts.OSV.Endpoint == "" {
+		e.opts.OSV.Endpoint = "https://api.osv.dev/v1/query"
+	}
+	if e.opts.NVD.Endpoint == "" {
+		e.opts.NVD.Endpoint = "https://services.nvd.nist.gov/rest/json/cves/2.0"
+	}
+	return e
+}
+
+// Enrich calculates hashes for the supplied binaries and looks them up in the
+// configured CVE databases. It returns a slice of findings, preserving the
+// order of the input binaries. Errors hashing individual binaries are captured
+// within the Finding so that other binaries can still be processed.
+func (e *Enricher) Enrich(ctx context.Context, binaries []binaryinspector.Result) ([]Finding, error) {
+	db, err := e.loadDatabases()
+	if err != nil {
+		return nil, err
+	}
+
+	findings := make([]Finding, 0, len(binaries))
+	for _, bin := range binaries {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		default:
+		}
+
+		finding := Finding{Path: bin.Path}
+		if bin.Err != "" {
+			finding.Error = bin.Err
+			findings = append(findings, finding)
+			continue
+		}
+
+		hash, err := hashFile(bin.Path)
+		if err != nil {
+			finding.Error = err.Error()
+			findings = append(findings, finding)
+			continue
+		}
+		finding.Hash = hash
+		finding.CVEs = db[hash]
+		if e.onlineEnabled() {
+			online, lookupErr := e.lookupOnline(ctx, hash)
+			if lookupErr != nil {
+				e.logger.Printf("online lookup %s: %v", hash, lookupErr)
+			}
+			if len(online) > 0 {
+				finding.CVEs = mergeCVEs(finding.CVEs, online)
+			}
+		}
+		findings = append(findings, finding)
+	}
+	return findings, nil
+}
+
+func (e *Enricher) loadDatabases() (map[string][]CVE, error) {
+	var sources []map[string][]CVE
+
+	if !e.opts.DisableEmbedded && len(embeddedCuratedDatabase) > 0 {
+		entries, err := ParseDatabase(embeddedCuratedDatabase)
+		if err != nil {
+			return nil, fmt.Errorf("parse embedded database: %w", err)
+		}
+		sources = append(sources, entries)
+	}
+
+	for _, path := range e.opts.DatabasePaths {
+		if strings.TrimSpace(path) == "" {
+			continue
+		}
+		path = filepath.Clean(path)
+		data, err := os.ReadFile(path)
+		if err != nil {
+			if os.IsNotExist(err) {
+				e.logger.Printf("skip vulnerability database %s: %v", path, err)
+				continue
+			}
+			e.logger.Printf("skip vulnerability database %s: %v", path, err)
+			continue
+		}
+		entries, err := ParseDatabase(data)
+		if err != nil {
+			e.logger.Printf("skip vulnerability database %s: %v", path, err)
+			continue
+		}
+		sources = append(sources, entries)
+	}
+
+	if len(sources) == 0 && (e.opts.DisableEmbedded || len(embeddedCuratedDatabase) == 0) {
+		return make(map[string][]CVE), nil
+	}
+	return Merge(sources...), nil
+}
+
+func hashFile(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", fmt.Errorf("open binary: %w", err)
+	}
+	defer f.Close()
+
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", fmt.Errorf("hash binary: %w", err)
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+// ParseDatabase decodes vulnerability data encoded either as a direct map of
+// hashes to CVE slices or as an artifacts array. Hashes are normalised to
+// lowercase hexadecimal strings without algorithm prefixes.
+func ParseDatabase(data []byte) (map[string][]CVE, error) {
+	// Support the "artifacts" structured representation used by some feeds.
+	var wrapper struct {
+		Artifacts []struct {
+			SHA256 string `json:"sha256"`
+			CVEs   []CVE  `json:"cves"`
+		} `json:"artifacts"`
+	}
+	if err := json.Unmarshal(data, &wrapper); err == nil && len(wrapper.Artifacts) > 0 {
+		out := make(map[string][]CVE)
+		for _, art := range wrapper.Artifacts {
+			if art.SHA256 == "" {
+				continue
+			}
+			out[normalizeHash(art.SHA256)] = append(out[normalizeHash(art.SHA256)], art.CVEs...)
+		}
+		return out, nil
+	}
+
+	// Fall back to simple hash -> []CVE maps.
+	var direct map[string][]CVE
+	if err := json.Unmarshal(data, &direct); err == nil {
+		if direct == nil {
+			direct = make(map[string][]CVE)
+		}
+		return direct, nil
+	}
+	return nil, errors.New("unrecognised database format")
+}
+
+func normalizeHash(value string) string {
+	cleaned := strings.TrimSpace(strings.ToLower(value))
+	if strings.HasPrefix(cleaned, "sha256:") {
+		cleaned = strings.TrimPrefix(cleaned, "sha256:")
+	}
+	return cleaned
+}
+
+// Merge combines one or more vulnerability databases into a single map keyed
+// by SHA-256 hash. CVE entries are deduplicated by ID, metadata is merged, and
+// references are normalised.
+func Merge(databases ...map[string][]CVE) map[string][]CVE {
+	combined := make(map[string][]CVE)
+	for _, db := range databases {
+		if db == nil {
+			continue
+		}
+		for hash, cves := range db {
+			normalized := normalizeHash(hash)
+			if normalized == "" {
+				continue
+			}
+			combined[normalized] = mergeCVEs(combined[normalized], cves)
+		}
+	}
+	return combined
+}
+
+func mergeCVEs(existing []CVE, incoming []CVE) []CVE {
+	if len(incoming) == 0 {
+		return existing
+	}
+
+	seen := make(map[string]int, len(existing))
+	for i, c := range existing {
+		key := strings.ToLower(strings.TrimSpace(c.ID))
+		if key == "" {
+			continue
+		}
+		dedupeReferences(&existing[i])
+		seen[key] = i
+	}
+
+	for _, c := range incoming {
+		key := strings.ToLower(strings.TrimSpace(c.ID))
+		if key == "" {
+			continue
+		}
+		dedupeReferences(&c)
+		if idx, ok := seen[key]; ok {
+			existing[idx] = mergeCVE(existing[idx], c)
+		} else {
+			seen[key] = len(existing)
+			existing = append(existing, c)
+		}
+	}
+
+	sort.Slice(existing, func(i, j int) bool {
+		return strings.ToLower(existing[i].ID) < strings.ToLower(existing[j].ID)
+	})
+	for i := range existing {
+		dedupeReferences(&existing[i])
+	}
+	return existing
+}
+
+func mergeCVE(base CVE, update CVE) CVE {
+	result := base
+	if result.ID == "" {
+		result.ID = update.ID
+	}
+
+	result.Severity = pickSeverity(result.Severity, update.Severity)
+
+	if result.Description == "" {
+		result.Description = update.Description
+	}
+
+	result.References = mergeReferences(result.References, update.References)
+	return result
+}
+
+func pickSeverity(current, candidate string) string {
+	current = strings.ToLower(strings.TrimSpace(current))
+	candidate = strings.ToLower(strings.TrimSpace(candidate))
+	ranks := map[string]int{"critical": 4, "high": 3, "medium": 2, "moderate": 2, "low": 1, "info": 0, "informational": 0}
+	if ranks[candidate] > ranks[current] {
+		return candidate
+	}
+	return current
+}
+
+func mergeReferences(existing, incoming []string) []string {
+	refs := make([]string, 0, len(existing)+len(incoming))
+	seen := make(map[string]struct{}, len(existing)+len(incoming))
+	for _, r := range existing {
+		r = strings.TrimSpace(r)
+		if r == "" {
+			continue
+		}
+		key := strings.ToLower(r)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		refs = append(refs, r)
+	}
+	for _, r := range incoming {
+		r = strings.TrimSpace(r)
+		if r == "" {
+			continue
+		}
+		key := strings.ToLower(r)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		refs = append(refs, r)
+	}
+	sort.Strings(refs)
+	return refs
+}
+
+func dedupeReferences(c *CVE) {
+	c.References = mergeReferences(nil, c.References)
+}
+
+func (e *Enricher) onlineEnabled() bool {
+	return (e.opts.OSV.Enabled && !e.disableOSV) || (e.opts.NVD.Enabled && !e.disableNVD)
+}
+
+func (e *Enricher) lookupOnline(ctx context.Context, hash string) ([]CVE, error) {
+	if entry, ok := e.fromCache(hash); ok {
+		return entry.CVEs, nil
+	}
+	var combined []CVE
+	var errs []string
+	if e.opts.OSV.Enabled && !e.disableOSV {
+		cves, err := e.queryOSV(ctx, hash)
+		if err != nil {
+			if e.disableOnPermanentError("osv", err) {
+				errs = append(errs, fmt.Sprintf("osv disabled: %v", err))
+			} else {
+				errs = append(errs, fmt.Sprintf("osv: %v", err))
+			}
+		} else if len(cves) > 0 {
+			combined = mergeCVEs(combined, cves)
+		}
+	}
+	if e.opts.NVD.Enabled && !e.disableNVD {
+		cves, err := e.queryNVD(ctx, hash)
+		if err != nil {
+			if e.disableOnPermanentError("nvd", err) {
+				errs = append(errs, fmt.Sprintf("nvd disabled: %v", err))
+			} else {
+				errs = append(errs, fmt.Sprintf("nvd: %v", err))
+			}
+		} else if len(cves) > 0 {
+			combined = mergeCVEs(combined, cves)
+		}
+	}
+	e.storeCache(hash, combined)
+	if len(errs) > 0 && len(combined) == 0 {
+		return combined, errors.New(strings.Join(errs, "; "))
+	}
+	return combined, nil
+}
+
+func (e *Enricher) fromCache(hash string) (cacheEntry, bool) {
+	if entry, ok := e.cache[hash]; ok {
+		return entry, true
+	}
+	if e.cacheDir == "" {
+		return cacheEntry{}, false
+	}
+	path := e.cacheFile(hash)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return cacheEntry{}, false
+	}
+	var entry cacheEntry
+	if err := json.Unmarshal(data, &entry); err != nil {
+		return cacheEntry{}, false
+	}
+	e.cache[hash] = entry
+	return entry, true
+}
+
+func (e *Enricher) storeCache(hash string, cves []CVE) {
+	entry := cacheEntry{CVEs: cves}
+	e.cache[hash] = entry
+	if e.cacheDir == "" {
+		return
+	}
+	data, err := json.Marshal(entry)
+	if err != nil {
+		return
+	}
+	if err := os.MkdirAll(e.cacheDir, 0o755); err != nil {
+		return
+	}
+	_ = os.WriteFile(e.cacheFile(hash), data, 0o644)
+}
+
+func (e *Enricher) cacheFile(hash string) string {
+	return filepath.Join(e.cacheDir, fmt.Sprintf("%s.json", hash))
+}
+
+func (e *Enricher) throttle(ctx context.Context) error {
+	if e.rateInterval <= 0 {
+		return nil
+	}
+	wait := e.rateInterval - time.Since(e.lastRequest)
+	if wait > 0 {
+		timer := time.NewTimer(wait)
+		defer timer.Stop()
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-timer.C:
+		}
+	}
+	e.lastRequest = time.Now()
+	return nil
+}
+
+func (e *Enricher) queryOSV(ctx context.Context, hash string) ([]CVE, error) {
+	if err := e.throttle(ctx); err != nil {
+		return nil, err
+	}
+	payload := map[string]string{"hash": "sha256:" + hash}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return nil, err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, e.opts.OSV.Endpoint, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := e.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 400 {
+		return nil, &providerError{provider: "osv", status: resp.StatusCode, message: fmt.Sprintf("http %s", resp.Status)}
+	}
+	var parsed struct {
+		Vulns []struct {
+			ID       string `json:"id"`
+			Summary  string `json:"summary"`
+			Details  string `json:"details"`
+			Severity []struct {
+				Type  string `json:"type"`
+				Score string `json:"score"`
+			} `json:"severity"`
+			References []struct {
+				URL string `json:"url"`
+			} `json:"references"`
+		} `json:"vulns"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
+		return nil, err
+	}
+	var out []CVE
+	for _, vuln := range parsed.Vulns {
+		cve := CVE{ID: vuln.ID}
+		if cve.Description == "" {
+			cve.Description = strings.TrimSpace(vuln.Summary)
+		}
+		if cve.Description == "" {
+			cve.Description = strings.TrimSpace(vuln.Details)
+		}
+		cve.Severity = pickOSVSeverity(vuln.Severity)
+		for _, ref := range vuln.References {
+			if ref.URL != "" {
+				cve.References = append(cve.References, ref.URL)
+			}
+		}
+		out = append(out, cve)
+	}
+	return out, nil
+}
+
+func (e *Enricher) queryNVD(ctx context.Context, hash string) ([]CVE, error) {
+	if err := e.throttle(ctx); err != nil {
+		return nil, err
+	}
+	endpoint, err := url.Parse(e.opts.NVD.Endpoint)
+	if err != nil {
+		return nil, err
+	}
+	q := endpoint.Query()
+	q.Set("sha256", hash)
+	endpoint.RawQuery = q.Encode()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+	if strings.TrimSpace(e.opts.NVD.APIKey) != "" {
+		req.Header.Set("X-Api-Key", strings.TrimSpace(e.opts.NVD.APIKey))
+	}
+	resp, err := e.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 400 {
+		return nil, &providerError{provider: "nvd", status: resp.StatusCode, message: fmt.Sprintf("http %s", resp.Status)}
+	}
+	var parsed struct {
+		Vulnerabilities []struct {
+			Cve struct {
+				ID           string `json:"id"`
+				Descriptions []struct {
+					Value string `json:"value"`
+				} `json:"descriptions"`
+				Metrics struct {
+					CvssMetricV31 []struct {
+						CvssData struct {
+							BaseSeverity string `json:"baseSeverity"`
+						} `json:"cvssData"`
+					} `json:"cvssMetricV31"`
+					CvssMetricV30 []struct {
+						CvssData struct {
+							BaseSeverity string `json:"baseSeverity"`
+						} `json:"cvssData"`
+					} `json:"cvssMetricV30"`
+					CvssMetricV2 []struct {
+						BaseSeverity string `json:"baseSeverity"`
+					} `json:"cvssMetricV2"`
+				} `json:"metrics"`
+				References struct {
+					ReferenceData []struct {
+						URL string `json:"url"`
+					} `json:"referenceData"`
+				} `json:"references"`
+			} `json:"cve"`
+		} `json:"vulnerabilities"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
+		return nil, err
+	}
+	var out []CVE
+	for _, entry := range parsed.Vulnerabilities {
+		cveData := entry.Cve
+		cve := CVE{ID: cveData.ID, Severity: pickNVDSeverity(cveData.Metrics)}
+		for _, desc := range cveData.Descriptions {
+			if strings.TrimSpace(desc.Value) != "" {
+				cve.Description = strings.TrimSpace(desc.Value)
+				break
+			}
+		}
+		for _, ref := range cveData.References.ReferenceData {
+			if ref.URL != "" {
+				cve.References = append(cve.References, ref.URL)
+			}
+		}
+		out = append(out, cve)
+	}
+	return out, nil
+}
+
+type providerError struct {
+	provider string
+	status   int
+	message  string
+}
+
+func (e *providerError) Error() string {
+	return e.message
+}
+
+func (e *providerError) Permanent() bool {
+	if e.status == http.StatusTooManyRequests {
+		return false
+	}
+	return e.status >= 400 && e.status < 500
+}
+
+func (e *providerError) Provider() string {
+	return e.provider
+}
+
+func (en *Enricher) disableOnPermanentError(provider string, err error) bool {
+	var perr *providerError
+	if !errors.As(err, &perr) || !perr.Permanent() {
+		return false
+	}
+	en.disableProvider(provider, perr)
+	return true
+}
+
+func (en *Enricher) disableProvider(provider string, err *providerError) {
+	switch provider {
+	case "osv":
+		if en.disableOSV {
+			return
+		}
+		en.disableOSV = true
+	case "nvd":
+		if en.disableNVD {
+			return
+		}
+		en.disableNVD = true
+	default:
+		return
+	}
+	en.logger.Printf("disable %s lookups after %s", provider, err.message)
+}
+
+func pickOSVSeverity(entries []struct {
+	Type  string `json:"type"`
+	Score string `json:"score"`
+}) string {
+	for _, entry := range entries {
+		if entry.Score != "" {
+			return strings.ToLower(entry.Score)
+		}
+		if entry.Type != "" {
+			return strings.ToLower(entry.Type)
+		}
+	}
+	return ""
+}
+
+func pickNVDSeverity(metrics struct {
+	CvssMetricV31 []struct {
+		CvssData struct {
+			BaseSeverity string `json:"baseSeverity"`
+		} `json:"cvssData"`
+	} `json:"cvssMetricV31"`
+	CvssMetricV30 []struct {
+		CvssData struct {
+			BaseSeverity string `json:"baseSeverity"`
+		} `json:"cvssData"`
+	} `json:"cvssMetricV30"`
+	CvssMetricV2 []struct {
+		BaseSeverity string `json:"baseSeverity"`
+	} `json:"cvssMetricV2"`
+}) string {
+	severityOrder := []string{
+		firstNVDSeverity(metrics.CvssMetricV31),
+		firstNVDSeverity(metrics.CvssMetricV30),
+	}
+	for _, sev := range severityOrder {
+		if sev != "" {
+			return strings.ToLower(sev)
+		}
+	}
+	if len(metrics.CvssMetricV2) > 0 {
+		return strings.ToLower(metrics.CvssMetricV2[0].BaseSeverity)
+	}
+	return ""
+}
+
+func firstNVDSeverity(metrics []struct {
+	CvssData struct {
+		BaseSeverity string `json:"baseSeverity"`
+	} `json:"cvssData"`
+}) string {
+	for _, metric := range metrics {
+		if metric.CvssData.BaseSeverity != "" {
+			return metric.CvssData.BaseSeverity
+		}
+	}
+	return ""
+}

--- a/tests/binaryinspector_test.go
+++ b/tests/binaryinspector_test.go
@@ -1,0 +1,71 @@
+package tests
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"firmwareanalyzer/pkg/binaryinspector"
+)
+
+func TestInspectDetectsELFBinary(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	src := filepath.Join(tmp, "main.go")
+	if err := os.WriteFile(src, []byte("package main\nfunc main(){}\n"), 0o644); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+
+	binPath := filepath.Join(tmp, "firmware")
+	cmd := exec.Command("go", "build", "-o", binPath, src)
+	cmd.Env = append(os.Environ(), "GOOS=linux", "GOARCH=amd64")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("build test binary: %v, output: %s", err, out)
+	}
+
+	inspector := binaryinspector.NewInspector(nil)
+	results, err := inspector.Inspect(context.Background(), tmp)
+	if err != nil {
+		t.Fatalf("inspect: %v", err)
+	}
+
+	var found bool
+	for _, res := range results {
+		if res.Path == binPath {
+			found = true
+			if res.Err != "" {
+				t.Fatalf("unexpected error in result: %s", res.Err)
+			}
+			if res.Architecture == "" {
+				t.Fatalf("architecture not detected: %+v", res)
+			}
+		}
+	}
+
+	if !found {
+		t.Fatalf("expected to find binary at %s", binPath)
+	}
+}
+
+func TestCollectMarkdownTable(t *testing.T) {
+	results := []binaryinspector.Result{{
+		Path:         "/tmp/bin",
+		Type:         "ET_DYN",
+		Architecture: "EM_X86_64",
+		RELRO:        binaryinspector.RELROFull,
+		NXEnabled:    true,
+		PIEEnabled:   true,
+		Stripped:     false,
+	}}
+
+	table := binaryinspector.CollectMarkdownTable(results)
+	if table == "" {
+		t.Fatal("expected non-empty table")
+	}
+	if got, want := table[:1], "|"; got != want {
+		t.Fatalf("table must start with '|' got %q", got)
+	}
+}

--- a/tests/configparser_test.go
+++ b/tests/configparser_test.go
@@ -1,0 +1,86 @@
+package tests
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"firmwareanalyzer/pkg/configparser"
+)
+
+func TestConfigParserParsesMultipleFormats(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	jsonPath := filepath.Join(root, "settings.json")
+	if err := os.WriteFile(jsonPath, []byte(`{"db":{"user":"root","password":"toor"}}`), 0o644); err != nil {
+		t.Fatalf("write json: %v", err)
+	}
+	xmlPath := filepath.Join(root, "config.xml")
+	if err := os.WriteFile(xmlPath, []byte(`<config><api token="abc123">value</api></config>`), 0o644); err != nil {
+		t.Fatalf("write xml: %v", err)
+	}
+	tomlPath := filepath.Join(root, "app.toml")
+	if err := os.WriteFile(tomlPath, []byte("[auth]\nkey = \"abcdef\"\n"), 0o644); err != nil {
+		t.Fatalf("write toml: %v", err)
+	}
+	iniPath := filepath.Join(root, "network.ini")
+	if err := os.WriteFile(iniPath, []byte("[wifi]\npassword=secret\n"), 0o644); err != nil {
+		t.Fatalf("write ini: %v", err)
+	}
+	yamlPath := filepath.Join(root, "drone.yaml")
+	yamlContent := "credentials:\n  token: abcdef123456\n  endpoints:\n    - https://example\n"
+	if err := os.WriteFile(yamlPath, []byte(yamlContent), 0o644); err != nil {
+		t.Fatalf("write yaml: %v", err)
+	}
+
+	parser := configparser.NewParser(nil)
+	findings, err := parser.Parse(context.Background(), root)
+	if err != nil {
+		t.Fatalf("parse configs: %v", err)
+	}
+
+	if len(findings) != 5 {
+		t.Fatalf("expected 5 findings, got %d", len(findings))
+	}
+
+	var credentialCount int
+	for _, finding := range findings {
+		for _, param := range finding.Params {
+			if param.Credential {
+				credentialCount++
+			}
+		}
+	}
+	if credentialCount == 0 {
+		t.Fatalf("expected credential heuristics to trigger")
+	}
+}
+
+func TestConfigParserSkipsMalformedXML(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	jsonPath := filepath.Join(root, "valid.json")
+	if err := os.WriteFile(jsonPath, []byte(`{"service":"ok"}`), 0o644); err != nil {
+		t.Fatalf("write json: %v", err)
+	}
+	badXML := filepath.Join(root, "broken.xml")
+	if err := os.WriteFile(badXML, []byte(`<config><value>bad&value</value></config>`), 0o644); err != nil {
+		t.Fatalf("write bad xml: %v", err)
+	}
+
+	parser := configparser.NewParser(nil)
+	findings, err := parser.Parse(context.Background(), root)
+	if err != nil {
+		t.Fatalf("parse configs: %v", err)
+	}
+
+	if len(findings) != 1 {
+		t.Fatalf("expected only the valid json to produce findings, got %d", len(findings))
+	}
+	if findings[0].File != jsonPath {
+		t.Fatalf("unexpected finding file %s", findings[0].File)
+	}
+}

--- a/tests/dashboard_test.go
+++ b/tests/dashboard_test.go
@@ -1,0 +1,134 @@
+package tests
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"firmwareanalyzer/pkg/dashboard"
+	"firmwareanalyzer/pkg/diff"
+	"firmwareanalyzer/pkg/report"
+)
+
+func TestDashboardStoreAndServer(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	logger := log.New(io.Discard, "test", log.LstdFlags)
+	store, err := dashboard.NewFileStore(dir, logger)
+	if err != nil {
+		t.Fatalf("store: %v", err)
+	}
+
+	ctx := context.Background()
+	summary1 := report.Summary{Firmware: "fw-a.bin"}
+	rec1, err := store.Record(ctx, summary1, report.Paths{}, nil, 120*time.Millisecond)
+	if err != nil {
+		t.Fatalf("record1: %v", err)
+	}
+	if _, err := os.Stat(rec1.SummaryPath); err != nil {
+		t.Fatalf("summary1 not written: %v", err)
+	}
+
+	diffSource := filepath.Join(dir, "diff-source.json")
+	if err := os.WriteFile(diffSource, []byte(`{"changes":true}`), 0o644); err != nil {
+		t.Fatalf("write diff source: %v", err)
+	}
+	summary2 := report.Summary{Firmware: "fw-b.bin"}
+	rec2, err := store.Record(ctx, summary2, report.Paths{}, &diff.Paths{JSON: diffSource}, 200*time.Millisecond)
+	if err != nil {
+		t.Fatalf("record2: %v", err)
+	}
+	if rec2.DiffPaths == nil || rec2.DiffPaths.JSON == "" {
+		t.Fatalf("diff path not persisted: %+v", rec2.DiffPaths)
+	}
+
+	records, err := store.List(ctx)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(records) != 2 {
+		t.Fatalf("expected 2 records, got %d", len(records))
+	}
+
+	loaded, err := store.LoadSummary(ctx, rec1.ID)
+	if err != nil {
+		t.Fatalf("load summary: %v", err)
+	}
+	if loaded.Firmware != summary1.Firmware {
+		t.Fatalf("unexpected firmware: %s", loaded.Firmware)
+	}
+
+	diffResult, err := store.Diff(ctx, rec2.ID, rec1.ID)
+	if err != nil {
+		t.Fatalf("diff: %v", err)
+	}
+	if diffResult.FirmwareNew != summary2.Firmware {
+		t.Fatalf("diff firmware mismatch: %s", diffResult.FirmwareNew)
+	}
+
+	srv := dashboard.NewServer(store, logger)
+	server := httptest.NewServer(srv.Handler())
+	t.Cleanup(server.Close)
+
+	// list endpoint
+	resp, err := http.Get(server.URL + "/api/records")
+	if err != nil {
+		t.Fatalf("records request: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("records status: %d", resp.StatusCode)
+	}
+	var apiRecords []dashboard.Record
+	if err := json.NewDecoder(resp.Body).Decode(&apiRecords); err != nil {
+		t.Fatalf("decode records: %v", err)
+	}
+	if len(apiRecords) != 2 {
+		t.Fatalf("expected 2 api records, got %d", len(apiRecords))
+	}
+
+	// detail endpoint
+	resp, err = http.Get(server.URL + "/api/records/" + rec1.ID)
+	if err != nil {
+		t.Fatalf("detail request: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("detail status: %d", resp.StatusCode)
+	}
+	var detail struct {
+		Record  dashboard.Record `json:"record"`
+		Summary report.Summary   `json:"summary"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&detail); err != nil {
+		t.Fatalf("decode detail: %v", err)
+	}
+	if detail.Summary.Firmware != summary1.Firmware {
+		t.Fatalf("detail summary mismatch: %s", detail.Summary.Firmware)
+	}
+
+	// diff endpoint
+	resp, err = http.Get(server.URL + "/api/diff?current=" + rec2.ID + "&baseline=" + rec1.ID)
+	if err != nil {
+		t.Fatalf("diff request: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("diff status: %d", resp.StatusCode)
+	}
+	var apiDiff diff.Result
+	if err := json.NewDecoder(resp.Body).Decode(&apiDiff); err != nil {
+		t.Fatalf("decode diff: %v", err)
+	}
+	if apiDiff.FirmwareNew != summary2.Firmware {
+		t.Fatalf("api diff mismatch: %s", apiDiff.FirmwareNew)
+	}
+}

--- a/tests/diff_test.go
+++ b/tests/diff_test.go
@@ -1,0 +1,123 @@
+package tests
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"firmwareanalyzer/pkg/configparser"
+	"firmwareanalyzer/pkg/diff"
+	"firmwareanalyzer/pkg/plugin"
+	"firmwareanalyzer/pkg/report"
+	"firmwareanalyzer/pkg/service"
+	"firmwareanalyzer/pkg/vuln"
+)
+
+func TestDiffComputeHighlightsChanges(t *testing.T) {
+	t.Parallel()
+
+	current := report.Summary{
+		Firmware: "new.bin",
+		Services: []service.Service{{Name: "httpd", Type: "init", Path: "/etc/init.d/httpd"}},
+		Configs: []configparser.Finding{{
+			File:   "/etc/config/system",
+			Params: []configparser.Parameter{{Key: "hostname", Value: "router"}},
+		}},
+	}
+	baseline := report.Summary{Firmware: "old.bin"}
+
+	result := diff.Compute(current, baseline)
+	if len(result.Services.Added) != 1 || !strings.Contains(result.Services.Added[0], "httpd") {
+		t.Fatalf("expected new service in diff, got %#v", result.Services)
+	}
+	if len(result.Configs.Added) != 1 {
+		t.Fatalf("expected config addition, got %#v", result.Configs)
+	}
+
+	outDir := t.TempDir()
+	paths, err := diff.WriteFiles(result, outDir, diff.Formats{Markdown: true, JSON: true})
+	if err != nil {
+		t.Fatalf("write diff: %v", err)
+	}
+	if _, err := os.Stat(paths.Markdown); err != nil {
+		t.Fatalf("missing markdown diff: %v", err)
+	}
+	if _, err := os.Stat(paths.JSON); err != nil {
+		t.Fatalf("missing json diff: %v", err)
+	}
+	data, err := os.ReadFile(paths.Markdown)
+	if err != nil {
+		t.Fatalf("read markdown: %v", err)
+	}
+	if !strings.Contains(string(data), "Firmware Analysis Diff") {
+		t.Fatalf("diff markdown missing heading")
+	}
+}
+
+func TestDiffCoversVulnerabilitiesAndPlugins(t *testing.T) {
+	t.Parallel()
+
+	current := report.Summary{
+		Vulnerable: []vuln.Finding{
+			{
+				Path: "/bin/httpd",
+				CVEs: []vuln.CVE{{ID: "CVE-2024-0001"}, {ID: "CVE-2023-9999"}},
+			},
+			{
+				Path: "/bin/new",
+				CVEs: []vuln.CVE{{ID: "CVE-2025-1111"}},
+			},
+		},
+		Plugins: []plugin.Result{
+			{
+				Plugin: "custom",
+				Findings: []plugin.Finding{{
+					Summary:  "Open debug interface",
+					Severity: "high",
+					Details:  map[string]any{"port": 31337},
+				}},
+			},
+		},
+	}
+
+	baseline := report.Summary{
+		Vulnerable: []vuln.Finding{
+			{
+				Path: "/bin/httpd",
+				CVEs: []vuln.CVE{{ID: "CVE-2024-0001"}},
+			},
+			{
+				Path: "/bin/old",
+				CVEs: []vuln.CVE{{ID: "CVE-2020-0001"}},
+			},
+		},
+		Plugins: []plugin.Result{
+			{
+				Plugin: "custom",
+				Findings: []plugin.Finding{{
+					Summary:  "Legacy shell access",
+					Severity: "medium",
+				}},
+			},
+		},
+	}
+
+	result := diff.Compute(current, baseline)
+
+	if len(result.Vulnerabilities.Added) != 1 {
+		t.Fatalf("expected new vulnerability entry, got %#v", result.Vulnerabilities)
+	}
+	if len(result.Vulnerabilities.Modified) != 1 {
+		t.Fatalf("expected modified vulnerability entry, got %#v", result.Vulnerabilities)
+	}
+	if len(result.Vulnerabilities.Removed) != 1 {
+		t.Fatalf("expected removed vulnerability entry, got %#v", result.Vulnerabilities)
+	}
+
+	if len(result.Plugins.Added) != 1 {
+		t.Fatalf("expected new plugin finding, got %#v", result.Plugins)
+	}
+	if len(result.Plugins.Removed) != 1 {
+		t.Fatalf("expected removed plugin finding, got %#v", result.Plugins)
+	}
+}

--- a/tests/extractor_test.go
+++ b/tests/extractor_test.go
@@ -1,0 +1,115 @@
+package tests
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"firmwareanalyzer/pkg/extractor"
+)
+
+func TestExtractorHandlesTarGz(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	firmwarePath := filepath.Join(tmp, "firmware.tgz")
+
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+	contents := map[string]string{
+		"etc/config.ini": "user=admin\npassword=secret\n",
+		"bin/app":        "#!/bin/sh\necho hi\n",
+	}
+	for name, data := range contents {
+		if err := tw.WriteHeader(&tar.Header{Name: name, Mode: 0o755, Size: int64(len(data))}); err != nil {
+			t.Fatalf("write header: %v", err)
+		}
+		if _, err := tw.Write([]byte(data)); err != nil {
+			t.Fatalf("write data: %v", err)
+		}
+	}
+	squash := append([]byte("hsqs"), bytes.Repeat([]byte{0}, 64)...)
+	if err := tw.WriteHeader(&tar.Header{Name: "rootfs.squashfs", Mode: 0o644, Size: int64(len(squash))}); err != nil {
+		t.Fatalf("write squash header: %v", err)
+	}
+	if _, err := tw.Write(squash); err != nil {
+		t.Fatalf("write squash data: %v", err)
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatalf("close tar: %v", err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatalf("close gzip: %v", err)
+	}
+	if err := os.WriteFile(firmwarePath, buf.Bytes(), 0o644); err != nil {
+		t.Fatalf("write firmware: %v", err)
+	}
+
+	ext := extractor.New(extractor.Options{ExternalExtractors: []string{}}, nil)
+	result, err := ext.Extract(context.Background(), firmwarePath)
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+
+	for name := range contents {
+		if _, err := os.Stat(filepath.Join(result.OutputDir, name)); err != nil {
+			t.Fatalf("expected extracted file %s: %v", name, err)
+		}
+	}
+	if len(result.Partitions) == 0 {
+		t.Fatalf("expected partition metadata, got %#v", result.Partitions)
+	}
+	var sawSquash bool
+	for _, part := range result.Partitions {
+		if part.Type == "squashfs" && strings.HasSuffix(part.Path, "rootfs.squashfs") {
+			sawSquash = part.Notes != "" && part.Compression != ""
+		}
+		if part.Type == "directory" && strings.Contains(part.Name, string(os.PathSeparator)) {
+			t.Fatalf("unexpected nested directory partition %q", part.Name)
+		}
+	}
+	if !sawSquash {
+		t.Fatalf("expected squashfs partition with notes, got %#v", result.Partitions)
+	}
+}
+
+func TestExtractorNormalizesSingleDirectoryRoot(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	firmwarePath := filepath.Join(tmp, "firmware.tar")
+
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	if err := tw.WriteHeader(&tar.Header{Name: "squashfs-root/", Mode: 0o755, Typeflag: tar.TypeDir}); err != nil {
+		t.Fatalf("write dir header: %v", err)
+	}
+	data := []byte("root:x:0:0:root:/root:/bin/sh\n")
+	if err := tw.WriteHeader(&tar.Header{Name: "squashfs-root/etc/passwd", Mode: 0o644, Size: int64(len(data))}); err != nil {
+		t.Fatalf("write file header: %v", err)
+	}
+	if _, err := tw.Write(data); err != nil {
+		t.Fatalf("write data: %v", err)
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatalf("close tar: %v", err)
+	}
+	if err := os.WriteFile(firmwarePath, buf.Bytes(), 0o644); err != nil {
+		t.Fatalf("write firmware: %v", err)
+	}
+
+	ext := extractor.New(extractor.Options{ExternalExtractors: []string{}}, nil)
+	result, err := ext.Extract(context.Background(), firmwarePath)
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	if !strings.HasSuffix(result.OutputDir, "squashfs-root") {
+		t.Fatalf("expected normalized root, got %s", result.OutputDir)
+	}
+}

--- a/tests/filesystem_test.go
+++ b/tests/filesystem_test.go
@@ -1,0 +1,105 @@
+package tests
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"firmwareanalyzer/pkg/filesystem"
+)
+
+func TestFilesystemDetectorRecognisesMagic(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	squash := filepath.Join(root, "rootfs.squashfs")
+	if err := os.WriteFile(squash, []byte("hsqs"), 0o644); err != nil {
+		t.Fatalf("write squashfs: %v", err)
+	}
+
+	detector := filesystem.NewDetector(nil)
+	mounts, err := detector.Detect(context.Background(), root)
+	if err != nil {
+		t.Fatalf("detect: %v", err)
+	}
+
+	var found bool
+	for _, mnt := range mounts {
+		if mnt.ImagePath == squash && mnt.Type == "squashfs" {
+			if mnt.Offset != 0 {
+				t.Fatalf("expected zero offset for standalone squashfs, got %d", mnt.Offset)
+			}
+			if mnt.Notes == "" {
+				t.Fatalf("expected notes for squashfs mount")
+			}
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected squashfs mount in %#v", mounts)
+	}
+}
+
+func TestFilesystemDetectorDetectsLikelyRootDirectories(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	nestedRoot := filepath.Join(root, "img", "rootfs")
+	if err := os.MkdirAll(filepath.Join(nestedRoot, "etc"), 0o755); err != nil {
+		t.Fatalf("mkdir etc: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(nestedRoot, "bin"), 0o755); err != nil {
+		t.Fatalf("mkdir bin: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(nestedRoot, "etc", "fstab"), []byte(""), 0o644); err != nil {
+		t.Fatalf("write fstab: %v", err)
+	}
+
+	detector := filesystem.NewDetector(nil)
+	mounts, err := detector.Detect(context.Background(), root)
+	if err != nil {
+		t.Fatalf("detect: %v", err)
+	}
+
+	var found bool
+	for _, mnt := range mounts {
+		if strings.HasSuffix(mnt.ImagePath, "rootfs") && mnt.Type == "directory" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected nested root directory mount in %#v", mounts)
+	}
+}
+
+func TestFilesystemDetectorDetectsMTDStrings(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	img := filepath.Join(root, "flash.bin")
+	data := []byte("bootloader\nmtdparts=flash:512k@0(boot);1536k@0x80000(rootfs)")
+	if err := os.WriteFile(img, data, 0o644); err != nil {
+		t.Fatalf("write flash: %v", err)
+	}
+
+	detector := filesystem.NewDetector(nil)
+	mounts, err := detector.Detect(context.Background(), root)
+	if err != nil {
+		t.Fatalf("detect: %v", err)
+	}
+
+	var found bool
+	for _, mnt := range mounts {
+		if mnt.Type == "mtd" && strings.HasSuffix(mnt.ImagePath, "flash.bin") {
+			if !strings.Contains(mnt.Notes, "mtdparts") {
+				t.Fatalf("expected mtd notes, got %s", mnt.Notes)
+			}
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected mtd detection in %#v", mounts)
+	}
+}

--- a/tests/plugin_test.go
+++ b/tests/plugin_test.go
@@ -1,0 +1,66 @@
+package tests
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"firmwareanalyzer/pkg/plugin"
+)
+
+func TestPluginRunnerExecutesScripts(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell scripts not supported on Windows in tests")
+	}
+	t.Parallel()
+
+	dir := t.TempDir()
+	script := filepath.Join(dir, "sample.sh")
+	content := "#!/bin/sh\n" +
+		"payload=$(cat)\n" +
+		"echo \"$payload\" | grep -q sample.bin || exit 1\n" +
+		"[ \"$ANALYZER_METADATA_FORMAT\" = \"json\" ] || exit 1\n" +
+		"[ -n \"$ANALYZER_ROOT\" ] || exit 1\n" +
+		"printf '[{\"summary\":\"ok\",\"severity\":\"low\"}]'\n"
+	if err := os.WriteFile(script, []byte(content), 0o755); err != nil {
+		t.Fatalf("write script: %v", err)
+	}
+
+	runner := plugin.NewRunner(nil, plugin.Options{Directory: dir})
+	root := t.TempDir()
+	results, err := runner.Run(context.Background(), plugin.Metadata{Firmware: "sample.bin", Root: root})
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected single plugin result, got %d", len(results))
+	}
+	if len(results[0].Findings) != 1 || results[0].Findings[0].Summary != "ok" {
+		t.Fatalf("unexpected findings: %#v", results[0].Findings)
+	}
+}
+
+func TestPluginRunnerCapturesErrors(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell scripts not supported on Windows in tests")
+	}
+	t.Parallel()
+
+	dir := t.TempDir()
+	script := filepath.Join(dir, "fail.sh")
+	content := "#!/bin/sh\necho error >&2\nexit 1"
+	if err := os.WriteFile(script, []byte(content), 0o755); err != nil {
+		t.Fatalf("write script: %v", err)
+	}
+
+	runner := plugin.NewRunner(nil, plugin.Options{Directory: dir})
+	results, err := runner.Run(context.Background(), plugin.Metadata{Firmware: "sample.bin", Root: t.TempDir()})
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if len(results) != 1 || results[0].Error == "" {
+		t.Fatalf("expected plugin error to be captured: %#v", results)
+	}
+}

--- a/tests/report_test.go
+++ b/tests/report_test.go
@@ -1,0 +1,144 @@
+package tests
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"firmwareanalyzer/pkg/binaryinspector"
+	"firmwareanalyzer/pkg/extractor"
+	"firmwareanalyzer/pkg/filesystem"
+	"firmwareanalyzer/pkg/plugin"
+	"firmwareanalyzer/pkg/report"
+	"firmwareanalyzer/pkg/sbom"
+	"firmwareanalyzer/pkg/vuln"
+)
+
+func TestReportMarkdownContainsSections(t *testing.T) {
+	summary := report.Summary{
+		Firmware: "sample.bin",
+		Extraction: &extractor.Result{
+			OutputDir: "/tmp/out",
+			Partitions: []extractor.Partition{{
+				Name:        "rootfs.squashfs",
+				Path:        "/tmp/out/rootfs.squashfs",
+				Type:        "squashfs",
+				Size:        1024,
+				Offset:      4096,
+				Notes:       "detected via extension",
+				Entropy:     7.8,
+				Compression: "high",
+			}},
+		},
+		FileSystems: []filesystem.Mount{{
+			ImagePath: "/tmp/out/rootfs.squashfs",
+			Type:      "squashfs",
+			Size:      1024,
+			Offset:    0,
+			Notes:     "magic matched",
+		}},
+		Binaries: []binaryinspector.Result{{Path: "/bin/app"}},
+	}
+
+	gen := report.NewGenerator(nil)
+	md := gen.Markdown(summary)
+	if md == "" {
+		t.Fatalf("expected markdown output")
+	}
+	if !strings.Contains(md, "# Drone Firmware Analyzer Report") {
+		t.Fatalf("missing heading: %s", md)
+	}
+	if !strings.Contains(md, "Compression") {
+		t.Fatalf("expected compression column: %s", md)
+	}
+}
+
+func TestReportWriteFilesHonoursFormats(t *testing.T) {
+	t.Parallel()
+
+	summary := report.Summary{
+		Firmware: "sample.bin",
+		Extraction: &extractor.Result{
+			OutputDir: "/tmp/out",
+		},
+		SBOM: &sbom.Document{Format: sbom.FormatSPDX},
+	}
+	gen := report.NewGenerator(nil)
+	outDir := t.TempDir()
+	paths, err := gen.WriteFiles(summary, outDir, report.Formats{Markdown: true, JSON: true})
+	if err != nil {
+		t.Fatalf("write files: %v", err)
+	}
+	if paths.HTML != "" {
+		t.Fatalf("expected html path to be empty when not requested, got %s", paths.HTML)
+	}
+	if _, err := os.Stat(paths.Markdown); err != nil {
+		t.Fatalf("missing markdown file: %v", err)
+	}
+	if _, err := os.Stat(paths.JSON); err != nil {
+		t.Fatalf("missing json file: %v", err)
+	}
+	data, err := os.ReadFile(paths.JSON)
+	if err != nil {
+		t.Fatalf("read json: %v", err)
+	}
+	if !strings.Contains(string(data), "sample.bin") {
+		t.Fatalf("expected firmware name in json, got %s", string(data))
+	}
+	mdData, err := os.ReadFile(paths.Markdown)
+	if err != nil {
+		t.Fatalf("read markdown: %v", err)
+	}
+	if !strings.Contains(string(mdData), "Drone Firmware Analyzer Report") {
+		t.Fatalf("markdown missing heading")
+	}
+	if filepath.Dir(paths.Markdown) != outDir {
+		t.Fatalf("markdown path outside output dir")
+	}
+}
+
+func TestReportIncludesVulnerabilitiesAndPlugins(t *testing.T) {
+	summary := report.Summary{
+		Firmware: "sample.bin",
+		Vulnerable: []vuln.Finding{{
+			Path: "bin/app",
+			Hash: "abc",
+			CVEs: []vuln.CVE{{ID: "CVE-2024-0001"}},
+		}},
+		Plugins: []plugin.Result{{
+			Plugin: "custom",
+			Findings: []plugin.Finding{{
+				Summary:  "issue",
+				Severity: "medium",
+			}},
+		}},
+	}
+	gen := report.NewGenerator(nil)
+	md := gen.Markdown(summary)
+	if !strings.Contains(md, "Vulnerabilities") {
+		t.Fatalf("expected vulnerabilities section")
+	}
+	if !strings.Contains(md, "Plugin Findings") {
+		t.Fatalf("expected plugin section")
+	}
+}
+
+func TestReportLoadJSON(t *testing.T) {
+	t.Parallel()
+
+	summary := report.Summary{Firmware: "sample.bin"}
+	gen := report.NewGenerator(nil)
+	outDir := t.TempDir()
+	paths, err := gen.WriteFiles(summary, outDir, report.Formats{JSON: true})
+	if err != nil {
+		t.Fatalf("write files: %v", err)
+	}
+	loaded, err := report.LoadJSON(paths.JSON)
+	if err != nil {
+		t.Fatalf("load json: %v", err)
+	}
+	if loaded.Firmware != "sample.bin" {
+		t.Fatalf("unexpected firmware %s", loaded.Firmware)
+	}
+}

--- a/tests/sbom_test.go
+++ b/tests/sbom_test.go
@@ -1,0 +1,140 @@
+package tests
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/pem"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"firmwareanalyzer/pkg/binaryinspector"
+	"firmwareanalyzer/pkg/extractor"
+	"firmwareanalyzer/pkg/sbom"
+)
+
+func TestSBOMGeneratorReadsOpkgControls(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	controlDir := filepath.Join(root, "usr", "lib", "opkg", "info")
+	if err := os.MkdirAll(controlDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	control := "Package: busybox\nVersion: 1.36.0\nMaintainer: OpenWrt\n"
+	if err := os.WriteFile(filepath.Join(controlDir, "busybox.control"), []byte(control), 0o644); err != nil {
+		t.Fatalf("write control: %v", err)
+	}
+
+	gen, err := sbom.NewGenerator(nil, sbom.Options{Formats: []sbom.Format{sbom.FormatSPDXJSON}, ProductName: "test"})
+	if err != nil {
+		t.Fatalf("new generator: %v", err)
+	}
+	part := extractor.Partition{Name: "rootfs", Path: root, Type: "directory"}
+	doc, err := gen.Generate(context.Background(), root, nil, []extractor.Partition{part})
+	if err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+	if len(doc.Packages) != 1 {
+		t.Fatalf("expected 1 package, got %d", len(doc.Packages))
+	}
+	if doc.Packages[0].Name != "busybox" || doc.Packages[0].Version != "1.36.0" {
+		t.Fatalf("unexpected package data: %#v", doc.Packages[0])
+	}
+	if len(doc.Partitions) != 1 || doc.Partitions[0].Name != "rootfs" {
+		t.Fatalf("expected partition metadata, got %#v", doc.Partitions)
+	}
+}
+
+func TestSBOMGeneratorFallsBackToBinaries(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	binPath := filepath.Join(root, "bin", "app")
+	if err := os.MkdirAll(filepath.Dir(binPath), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(binPath, []byte("binary"), 0o755); err != nil {
+		t.Fatalf("write binary: %v", err)
+	}
+
+	gen, err := sbom.NewGenerator(nil, sbom.Options{Formats: []sbom.Format{sbom.FormatCycloneDX}})
+	if err != nil {
+		t.Fatalf("new generator: %v", err)
+	}
+	doc, err := gen.Generate(context.Background(), root, []binaryinspector.Result{{Path: binPath}}, nil)
+	if err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+	if len(doc.Packages) != 1 || doc.Packages[0].Name != "app" {
+		t.Fatalf("expected fallback package, got %#v", doc.Packages)
+	}
+}
+
+func TestSBOMWriteJSON(t *testing.T) {
+	t.Parallel()
+
+	doc := sbom.Document{Format: sbom.FormatSPDXJSON, Name: "test"}
+	out := filepath.Join(t.TempDir(), "sbom.json")
+	if err := sbom.WriteJSON(doc, out); err != nil {
+		t.Fatalf("write json: %v", err)
+	}
+	if _, err := os.Stat(out); err != nil {
+		t.Fatalf("sbom file missing: %v", err)
+	}
+}
+
+func TestSBOMEncodeTagValueAndSigning(t *testing.T) {
+	t.Parallel()
+
+	_, key, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	pkcs8, err := x509.MarshalPKCS8PrivateKey(key)
+	if err != nil {
+		t.Fatalf("marshal key: %v", err)
+	}
+	pemData := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: pkcs8})
+	keyPath := filepath.Join(t.TempDir(), "key.pem")
+	if err := os.WriteFile(keyPath, pemData, 0o600); err != nil {
+		t.Fatalf("write key: %v", err)
+	}
+
+	gen, err := sbom.NewGenerator(nil, sbom.Options{Formats: []sbom.Format{sbom.FormatSPDXTagValue}, SigningKeyPath: keyPath})
+	if err != nil {
+		t.Fatalf("new generator: %v", err)
+	}
+	doc := sbom.Document{Format: sbom.FormatSPDXTagValue, Name: "firmware"}
+	data, ext, err := sbom.Encode(doc, sbom.FormatSPDXTagValue)
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	if ext != "spdx" {
+		t.Fatalf("unexpected extension %s", ext)
+	}
+	sig, err := gen.Sign(data)
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	if len(sig) != ed25519.SignatureSize {
+		t.Fatalf("unexpected signature length %d", len(sig))
+	}
+	if len(data) == 0 {
+		t.Fatalf("expected tag-value content")
+	}
+}
+
+func TestSBOMGeneratorWarnsOnMissingKey(t *testing.T) {
+	t.Parallel()
+
+	gen, err := sbom.NewGenerator(nil, sbom.Options{Formats: []sbom.Format{sbom.FormatSPDXJSON}, SigningKeyPath: "missing-key.pem"})
+	if err != nil {
+		t.Fatalf("expected missing key to be ignored: %v", err)
+	}
+	if gen.Signer() {
+		t.Fatalf("expected signer to be disabled when key is missing")
+	}
+}

--- a/tests/scheduler_test.go
+++ b/tests/scheduler_test.go
@@ -1,0 +1,97 @@
+package tests
+
+import (
+	"context"
+	"io"
+	"log"
+	"sync"
+	"testing"
+
+	"firmwareanalyzer/pkg/scheduler"
+)
+
+func TestSchedulerLocalAndRemote(t *testing.T) {
+	t.Parallel()
+
+	var mu sync.Mutex
+	var commands [][]string
+	execFn := scheduler.ExecFunc(func(ctx context.Context, name string, args ...string) error {
+		mu.Lock()
+		defer mu.Unlock()
+		cmd := append([]string{name}, args...)
+		commands = append(commands, cmd)
+		return nil
+	})
+
+	opts := scheduler.Options{
+		AnalyzerPath:   "analyzer-bin",
+		Concurrency:    2,
+		Logger:         log.New(io.Discard, "sched", log.LstdFlags),
+		LocalExecutor:  execFn,
+		RemoteExecutor: execFn,
+		RemoteHosts: map[string]scheduler.RemoteHost{
+			"remote": {Name: "remote", Address: "remote.example", User: "root", AnalyzerPath: "/opt/analyzer", SSHBinary: "ssh"},
+		},
+	}
+	sched := scheduler.New(opts)
+	results := sched.Start(context.Background())
+
+	done := make(chan []scheduler.Result)
+	go func() {
+		var res []scheduler.Result
+		for r := range results {
+			res = append(res, r)
+		}
+		done <- res
+	}()
+
+	localJob := scheduler.Job{Firmware: "fw1.bin", OutputDir: "/tmp/out1", HistoryDir: "history", ReportFormats: []string{"json"}}
+	if err := sched.Enqueue(localJob); err != nil {
+		t.Fatalf("enqueue local: %v", err)
+	}
+	remoteJob := scheduler.Job{Firmware: "fw2.bin", OutputDir: "/tmp/out2", RemoteHost: "remote", ExtraArgs: []string{"--enable-osv"}}
+	if err := sched.Enqueue(remoteJob); err != nil {
+		t.Fatalf("enqueue remote: %v", err)
+	}
+
+	sched.Close()
+	got := <-done
+
+	if len(got) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(got))
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(commands) != 2 {
+		t.Fatalf("expected 2 commands, got %d", len(commands))
+	}
+	expected := [][]string{
+		{"analyzer-bin", "--fw", "fw1.bin", "--out", "/tmp/out1", "--history-dir", "history", "--report-formats", "json"},
+		{"ssh", "root@remote.example", "/opt/analyzer", "--fw", "fw2.bin", "--out", "/tmp/out2", "--enable-osv"},
+	}
+	for _, want := range expected {
+		found := false
+		for _, cmd := range commands {
+			if equalSlices(cmd, want) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("expected command %v not observed: %v", want, commands)
+		}
+	}
+}
+
+func equalSlices(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/tests/secrets_test.go
+++ b/tests/secrets_test.go
@@ -1,0 +1,105 @@
+package tests
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"firmwareanalyzer/pkg/secrets"
+)
+
+func TestSecretsScannerFindsPasswords(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	file := filepath.Join(root, "credentials.txt")
+	if err := os.WriteFile(file, []byte("username=admin\npassword=SuperSecret123\n"), 0o644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	scanner := secrets.NewScanner(nil, nil)
+	findings, err := scanner.Scan(context.Background(), root)
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+
+	if len(findings) == 0 {
+		t.Fatalf("expected secret finding, got %#v", findings)
+	}
+
+	var hasPassword bool
+	for _, finding := range findings {
+		if finding.Rule == "Password Assignment" {
+			hasPassword = true
+		}
+	}
+	if !hasPassword {
+		t.Fatalf("expected password assignment rule, got %#v", findings)
+	}
+}
+
+func TestSecretsScannerDetectsJWTAndAllowsSuppression(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	file := filepath.Join(root, "tokens.txt")
+	jwt := "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkRyb25lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
+	slack := "xoxb-1234567890-token"
+	content := "JWT=" + jwt + "\nSLACK=" + slack + "\n"
+	if err := os.WriteFile(file, []byte(content), 0o644); err != nil {
+		t.Fatalf("write token file: %v", err)
+	}
+
+	scanner := secrets.NewScanner(nil, nil)
+	findings, err := scanner.Scan(context.Background(), root)
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+
+	var hasJWT, hasSlack bool
+	for _, finding := range findings {
+		if finding.Rule == "JWT" {
+			hasJWT = true
+		}
+		if finding.Rule == "Slack Token" {
+			hasSlack = true
+		}
+	}
+	if !hasJWT || !hasSlack {
+		t.Fatalf("expected jwt and slack detections, got %#v", findings)
+	}
+
+	opts := secrets.ScannerOptions{
+		AllowRulePatterns: map[string][]string{
+			"Slack Token": {"xoxb-*"},
+		},
+	}
+	scanner = secrets.NewScannerWithOptions(nil, opts)
+	findings, err = scanner.Scan(context.Background(), root)
+	if err != nil {
+		t.Fatalf("scan with suppression: %v", err)
+	}
+	for _, finding := range findings {
+		if finding.Rule == "Slack Token" {
+			t.Fatalf("expected slack token to be suppressed, got %#v", findings)
+		}
+	}
+}
+
+func TestSecretsScannerHandlesLongLines(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	file := filepath.Join(root, "long.txt")
+	longValue := strings.Repeat("A", 200000)
+	if err := os.WriteFile(file, []byte("token="+longValue), 0o644); err != nil {
+		t.Fatalf("write long file: %v", err)
+	}
+
+	scanner := secrets.NewScanner(nil, nil)
+	if _, err := scanner.Scan(context.Background(), root); err != nil {
+		t.Fatalf("scan long file: %v", err)
+	}
+}

--- a/tests/service_test.go
+++ b/tests/service_test.go
@@ -1,0 +1,34 @@
+package tests
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"firmwareanalyzer/pkg/service"
+)
+
+func TestServiceDetectorFindsInitScripts(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	initDir := filepath.Join(root, "etc", "init.d")
+	if err := os.MkdirAll(initDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	script := filepath.Join(initDir, "S10daemon")
+	if err := os.WriteFile(script, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("write script: %v", err)
+	}
+
+	detector := service.NewDetector(nil)
+	services, err := detector.Detect(context.Background(), root)
+	if err != nil {
+		t.Fatalf("detect: %v", err)
+	}
+
+	if len(services) == 0 {
+		t.Fatalf("expected services, got %#v", services)
+	}
+}

--- a/tests/utils_test.go
+++ b/tests/utils_test.go
@@ -1,0 +1,55 @@
+package tests
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"firmwareanalyzer/pkg/utils"
+)
+
+func TestFlattenProducesDotNotation(t *testing.T) {
+	input := map[string]any{
+		"db": map[string]any{
+			"host": "localhost",
+			"creds": map[string]any{
+				"user": "root",
+				"pass": "secret",
+			},
+		},
+	}
+	flat := utils.Flatten("", input)
+	if flat["db.host"] != "localhost" {
+		t.Fatalf("unexpected host: %v", flat["db.host"])
+	}
+	if _, ok := flat["db.creds.pass"]; !ok {
+		t.Fatalf("expected credential path in flattened map")
+	}
+}
+
+func TestShannonEntropyRanges(t *testing.T) {
+	if utils.ShannonEntropy("aaaaa") >= utils.ShannonEntropy("abc123XYZ") {
+		t.Fatalf("expected higher entropy for mixed string")
+	}
+}
+
+func TestLooksLikeRoot(t *testing.T) {
+	dir := t.TempDir()
+	must := func(err error) {
+		if err != nil {
+			t.Fatalf("setup: %v", err)
+		}
+	}
+	must(os.Mkdir(filepath.Join(dir, "etc"), 0o755))
+	must(os.Mkdir(filepath.Join(dir, "bin"), 0o755))
+	must(os.WriteFile(filepath.Join(dir, "etc", "fstab"), []byte(""), 0o644))
+
+	if !utils.LooksLikeRoot(dir) {
+		t.Fatalf("expected directory to look like root")
+	}
+
+	other := t.TempDir()
+	if utils.LooksLikeRoot(other) {
+		t.Fatalf("unexpected root detection for empty dir")
+	}
+}

--- a/tests/vuln_test.go
+++ b/tests/vuln_test.go
@@ -1,0 +1,252 @@
+package tests
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+
+	"firmwareanalyzer/pkg/binaryinspector"
+	"firmwareanalyzer/pkg/vuln"
+)
+
+func TestVulnerabilityEnrichmentMatchesDatabase(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	binPath := filepath.Join(tmp, "app.bin")
+	if err := os.WriteFile(binPath, []byte("firmware"), 0o644); err != nil {
+		t.Fatalf("write binary: %v", err)
+	}
+	sum := sha256.Sum256([]byte("firmware"))
+	hash := hex.EncodeToString(sum[:])
+
+	dbPath := filepath.Join(tmp, "db.json")
+	dbContent := "{\n  \"" + hash + "\": [{\n    \"id\": \"CVE-2024-0001\",\n    \"severity\": \"high\"\n  }]\n}"
+	if err := os.WriteFile(dbPath, []byte(dbContent), 0o644); err != nil {
+		t.Fatalf("write db: %v", err)
+	}
+
+	enricher := vuln.NewEnricher(nil, vuln.Options{DatabasePaths: []string{dbPath}})
+	findings, err := enricher.Enrich(context.Background(), []binaryinspector.Result{{Path: binPath}})
+	if err != nil {
+		t.Fatalf("enrich: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected one finding, got %d", len(findings))
+	}
+	if findings[0].Hash != hash {
+		t.Fatalf("unexpected hash %s", findings[0].Hash)
+	}
+	if len(findings[0].CVEs) != 1 || findings[0].CVEs[0].ID != "CVE-2024-0001" {
+		t.Fatalf("missing CVE match: %#v", findings[0].CVEs)
+	}
+}
+
+func TestVulnerabilityEnrichmentCapturesErrors(t *testing.T) {
+	t.Parallel()
+
+	enricher := vuln.NewEnricher(nil, vuln.Options{})
+	findings, err := enricher.Enrich(context.Background(), []binaryinspector.Result{{Path: "does-not-exist"}})
+	if err != nil {
+		t.Fatalf("enrich: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected one finding, got %d", len(findings))
+	}
+	if findings[0].Error == "" {
+		t.Fatalf("expected error message when hashing fails")
+	}
+}
+
+func TestVulnerabilityEnrichmentUsesEmbeddedDatabase(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	binPath := filepath.Join(tmp, "busybox.bin")
+	if err := os.WriteFile(binPath, []byte("firmware"), 0o644); err != nil {
+		t.Fatalf("write binary: %v", err)
+	}
+
+	enricher := vuln.NewEnricher(nil, vuln.Options{})
+	findings, err := enricher.Enrich(context.Background(), []binaryinspector.Result{{Path: binPath}})
+	if err != nil {
+		t.Fatalf("enrich: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected one finding, got %d", len(findings))
+	}
+	if len(findings[0].CVEs) == 0 {
+		t.Fatalf("expected embedded database to provide CVE matches")
+	}
+}
+
+func TestVulnerabilityEnrichmentSkipsMissingDatabase(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	binPath := filepath.Join(tmp, "firmware.bin")
+	if err := os.WriteFile(binPath, []byte("firmware"), 0o644); err != nil {
+		t.Fatalf("write binary: %v", err)
+	}
+
+	missing := filepath.Join(tmp, "missing.json")
+	opts := vuln.Options{DatabasePaths: []string{missing}, DisableEmbedded: true}
+	enricher := vuln.NewEnricher(nil, opts)
+	if _, err := enricher.Enrich(context.Background(), []binaryinspector.Result{{Path: binPath}}); err != nil {
+		t.Fatalf("enrich should skip missing database: %v", err)
+	}
+}
+
+func TestMergeNormalisesAndDeduplicates(t *testing.T) {
+	t.Parallel()
+
+	db1 := map[string][]vuln.CVE{
+		"SHA256:c3BF47EA1F4A4A605470313CACB3A44F4A461F68C6FAEAB07E737610CB5AC835": {
+			{ID: "CVE-2024-0001", Severity: "medium", References: []string{"https://example.com/a"}},
+		},
+	}
+	db2 := map[string][]vuln.CVE{
+		"c3bf47ea1f4a4a605470313cacb3a44f4a461f68c6faeab07e737610cb5ac835": {
+			{ID: "CVE-2024-0001", Severity: "high", References: []string{"https://example.com/a", "https://example.com/b"}},
+			{ID: "CVE-2020-10135", Severity: "low"},
+		},
+	}
+
+	merged := vuln.Merge(db1, db2)
+	if len(merged) != 1 {
+		t.Fatalf("expected one hash, got %d", len(merged))
+	}
+	list := merged["c3bf47ea1f4a4a605470313cacb3a44f4a461f68c6faeab07e737610cb5ac835"]
+	if len(list) != 2 {
+		t.Fatalf("expected two CVEs after merge, got %d", len(list))
+	}
+
+	var cve0001 vuln.CVE
+	for _, c := range list {
+		if c.ID == "CVE-2024-0001" {
+			cve0001 = c
+		}
+	}
+	if cve0001.Severity != "high" {
+		t.Fatalf("expected severity to prefer higher rank, got %q", cve0001.Severity)
+	}
+	if len(cve0001.References) != 2 {
+		t.Fatalf("expected deduplicated references, got %v", cve0001.References)
+	}
+}
+
+func TestVulnerabilityOnlineLookupCachesResults(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	binPath := filepath.Join(tmp, "firmware.bin")
+	content := []byte("firmware-data")
+	if err := os.WriteFile(binPath, content, 0o644); err != nil {
+		t.Fatalf("write binary: %v", err)
+	}
+	sum := sha256.Sum256(content)
+	expectedHash := "sha256:" + hex.EncodeToString(sum[:])
+
+	var requests int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&requests, 1)
+		defer r.Body.Close()
+		var payload map[string]string
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		if payload["hash"] != expectedHash {
+			http.Error(w, "unexpected hash", http.StatusBadRequest)
+			return
+		}
+		resp := map[string]any{
+			"vulns": []map[string]any{{
+				"id":         "CVE-2024-9999",
+				"summary":    "test vulnerability",
+				"references": []map[string]string{{"url": "https://example.com"}},
+			}},
+		}
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	opts := vuln.Options{
+		DisableEmbedded: true,
+		CacheDir:        filepath.Join(tmp, "cache"),
+		OSV:             vuln.OnlineOptions{Enabled: true, Endpoint: server.URL},
+		HTTPClient:      server.Client(),
+	}
+
+	enricher := vuln.NewEnricher(nil, opts)
+	findings, err := enricher.Enrich(context.Background(), []binaryinspector.Result{{Path: binPath}})
+	if err != nil {
+		t.Fatalf("enrich: %v", err)
+	}
+	if len(findings) != 1 || len(findings[0].CVEs) != 1 {
+		t.Fatalf("expected online CVE, got %#v", findings)
+	}
+	if atomic.LoadInt32(&requests) != 1 {
+		t.Fatalf("expected one HTTP request, got %d", requests)
+	}
+
+	// Recreate the enricher to ensure disk cache is used instead of hitting the server again.
+	enricherCached := vuln.NewEnricher(nil, opts)
+	_, err = enricherCached.Enrich(context.Background(), []binaryinspector.Result{{Path: binPath}})
+	if err != nil {
+		t.Fatalf("enrich (cached): %v", err)
+	}
+	if atomic.LoadInt32(&requests) != 1 {
+		t.Fatalf("expected cached result without extra HTTP calls, got %d", requests)
+	}
+}
+
+func TestVulnerabilityOnlineLookupDisablesAfterPermanentError(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	binOne := filepath.Join(tmp, "one.bin")
+	if err := os.WriteFile(binOne, []byte("one"), 0o644); err != nil {
+		t.Fatalf("write one: %v", err)
+	}
+	binTwo := filepath.Join(tmp, "two.bin")
+	if err := os.WriteFile(binTwo, []byte("two"), 0o644); err != nil {
+		t.Fatalf("write two: %v", err)
+	}
+
+	var requests int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&requests, 1)
+		w.WriteHeader(http.StatusBadRequest)
+	}))
+	defer server.Close()
+
+	opts := vuln.Options{
+		DisableEmbedded: true,
+		OSV:             vuln.OnlineOptions{Enabled: true, Endpoint: server.URL},
+		HTTPClient:      server.Client(),
+	}
+	enricher := vuln.NewEnricher(nil, opts)
+	binaries := []binaryinspector.Result{{Path: binOne}, {Path: binTwo}}
+
+	if _, err := enricher.Enrich(context.Background(), binaries); err != nil {
+		t.Fatalf("enrich: %v", err)
+	}
+	if got := atomic.LoadInt32(&requests); got != 1 {
+		t.Fatalf("expected one request before disabling, got %d", got)
+	}
+
+	if _, err := enricher.Enrich(context.Background(), binaries); err != nil {
+		t.Fatalf("enrich second run: %v", err)
+	}
+	if got := atomic.LoadInt32(&requests); got != 1 {
+		t.Fatalf("expected online provider to remain disabled, got %d requests", got)
+	}
+}


### PR DESCRIPTION
## Summary
- move generated reports into the local `FA_<firmware>` snapshot directory and mirror the remaining output tree for easier discovery
- update snapshot and vulnerability logic to move artefacts safely across filesystems and silence repeated online lookup failures by disabling noisy providers
- extend the CLI and vulnerability tests to cover the revised snapshot workflow and provider back-off behaviour

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d599361b8483269e40391fa6b7fd85